### PR TITLE
Update inventory add stock access and navigation

### DIFF
--- a/dgz_motorshop_system/admin/dashboard.php
+++ b/dgz_motorshop_system/admin/dashboard.php
@@ -58,12 +58,6 @@ $top = $pdo->query('SELECT p.*, SUM(oi.qty) as sold FROM order_items oi JOIN pro
                     Inventory
                 </a>
             </div>
-             <div class="nav-item">
-                <a href="stockEntry.php" class="nav-link ">
-                    <i class="fas fa-truck-loading nav-icon"></i>
-                    Stock Entry
-                </a>
-            </div>
         </nav>
     </aside>
 

--- a/dgz_motorshop_system/admin/inventory.php
+++ b/dgz_motorshop_system/admin/inventory.php
@@ -5,14 +5,6 @@ $pdo = db();
 $role = $_SESSION['role'] ?? '';
 $products = $pdo->query('SELECT * FROM products ORDER BY created_at DESC')->fetchAll();
 
-// Handle stock updates (admin only)
-if($role === 'admin' && isset($_POST['update_stock'])) {
-    $id = intval($_POST['id']);
-    $change = intval($_POST['change']);
-    $pdo->prepare('UPDATE products SET quantity = quantity + ? WHERE id = ?')->execute([$change,$id]);
-    header('Location: inventory.php'); exit;
-}
-
 // Handle export to CSV
 if(isset($_GET['export']) && $_GET['export'] == 'csv') {
     header('Content-Type: text/csv');
@@ -77,12 +69,6 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
                     Inventory
                 </a>
             </div>
-             <div class="nav-item">
-                <a href="stockEntry.php" class="nav-link ">
-                    <i class="fas fa-truck-loading nav-icon"></i>
-                    Stock Entry
-                </a>
-            </div>
         </nav>
     </aside>
     <!-- Main Content -->
@@ -113,33 +99,28 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
             </div>
         </header>
         
-        <a href="inventory.php?export=csv">Export CSV</a>   
+        <div class="inventory-actions">
+            <a href="stockEntry.php" class="btn-action add-stock-btn">Add Stock</a>
+            <a href="inventory.php?export=csv" class="btn-action export-btn">Export CSV</a>
+        </div>
+
         <table border="1" cellpadding="5">
             <tr>
                 <th>Code</th>
                 <th>Name</th>
                 <th>Quantity</th>
                 <th>Low Stock Threshold</th>
-                <th>Date Added</th><?php if($role==='admin') echo '<th>Update Stock</th>';?>
+                <th>Date Added</th>
             </tr>
-            <?php foreach($products as $p): 
-$low = $p['quantity'] <= $p['low_stock_threshold'];
-?>
+            <?php foreach($products as $p):
+                $low = $p['quantity'] <= $p['low_stock_threshold'];
+            ?>
             <tr style="<?php if($low) echo 'background-color:#fdd'; ?>">
                 <td><?=htmlspecialchars($p['code'])?></td>
                 <td><?=htmlspecialchars($p['name'])?></td>
                 <td><?=intval($p['quantity'])?></td>
                 <td><?=intval($p['low_stock_threshold'])?></td>
                 <td><?=$p['created_at']?></td>
-                <?php if($role==='admin'): ?>
-                <td>
-                    <form method="post" style="display:inline-block">
-                        <input type="hidden" name="id" value="<?=$p['id']?>">
-                        <input type="number" name="change" value="0" style="width:60px">
-                        <button name="update_stock">Apply</button>
-                    </form>
-                </td>
-                <?php endif; ?>
             </tr>
             <?php endforeach; ?>
         </table>

--- a/dgz_motorshop_system/admin/pos.php
+++ b/dgz_motorshop_system/admin/pos.php
@@ -119,12 +119,6 @@ foreach($items as $i=>$pid){
                     Inventory
                 </a>
             </div>
-             <div class="nav-item">
-                <a href="stockEntry.php" class="nav-link ">
-                    <i class="fas fa-truck-loading nav-icon"></i>
-                    Stock Entry
-                </a>
-            </div>
         </nav>
     </aside>
     <!-- Main Content -->

--- a/dgz_motorshop_system/admin/products.php
+++ b/dgz_motorshop_system/admin/products.php
@@ -67,12 +67,6 @@ $products = $pdo->query('SELECT * FROM products')->fetchAll();
                     Inventory
                 </a>
             </div>
-             <div class="nav-item">
-                <a href="stockEntry.php" class="nav-link ">
-                    <i class="fas fa-truck-loading nav-icon"></i>
-                    Stock Entry
-                </a>
-            </div>
         </nav>
     </aside>
 

--- a/dgz_motorshop_system/admin/sales.php
+++ b/dgz_motorshop_system/admin/sales.php
@@ -95,12 +95,6 @@ $end_record = min($offset + $records_per_page, $total_records);
                     Inventory
                 </a>
             </div>
-             <div class="nav-item">
-                <a href="stockEntry.php" class="nav-link ">
-                    <i class="fas fa-truck-loading nav-icon"></i>
-                    Stock Entry
-                </a>
-            </div>
         </nav>
     </aside>
 

--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -98,12 +98,6 @@ $recent_entries = $pdo->query("
                     Inventory
                 </a>
             </div>
-            <div class="nav-item">
-                <a href="stockEntry.php" class="nav-link active">
-                    <i class="fas fa-truck-loading nav-icon"></i>
-                    Stock Entry
-                </a>
-            </div>
         </nav>
     </aside>
 
@@ -134,6 +128,10 @@ $recent_entries = $pdo->query("
                 </div>
             </div>
         </header>
+
+        <div class="page-actions">
+            <a href="inventory.php" class="btn-action back-btn">Back to Inventory</a>
+        </div>
 
         <!-- Stock Entry Content -->
         <div class="dashboard-content">

--- a/dgz_motorshop_system/assets/css/inventory.css
+++ b/dgz_motorshop_system/assets/css/inventory.css
@@ -199,6 +199,47 @@ table td {
     font-size: 14px;
 }
 
+.inventory-actions {
+    margin-top: 24px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.btn-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 18px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 14px;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.add-stock-btn {
+    background: #3498db;
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(52, 152, 219, 0.25);
+}
+
+.add-stock-btn:hover {
+    background: #2c82c9;
+    box-shadow: 0 6px 18px rgba(52, 152, 219, 0.35);
+}
+
+.export-btn {
+    background: #f8fafc;
+    color: #1f2937;
+    border: 1px solid #d1d5db;
+}
+
+.export-btn:hover {
+    background: #e5ebf5;
+}
+
 table tr {
     transition: background 0.3s;
 }

--- a/dgz_motorshop_system/assets/css/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/stockEntry.css
@@ -1,3 +1,32 @@
+.page-actions {
+            margin: 24px 0;
+            display: flex;
+            justify-content: flex-end;
+        }
+
+.btn-action {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 18px;
+            border-radius: 8px;
+            font-weight: 600;
+            font-size: 14px;
+            text-decoration: none;
+            transition: all 0.2s ease;
+            white-space: nowrap;
+        }
+
+.back-btn {
+            background: #f8fafc;
+            color: #1f2937;
+            border: 1px solid #d1d5db;
+        }
+
+.back-btn:hover {
+            background: #e5ebf5;
+        }
+
 .stock-entry-form {
             background: white;
             padding: 24px;


### PR DESCRIPTION
## Summary
- restyled the inventory page actions so the Add Stock shortcut sits beside the CSV export and links to the dedicated stockEntry form
- removed inline stock adjustment forms and added complementary button styling updates in both inventory and stock entry stylesheets
- cleaned up admin sidebars by dropping the Stock Entry link and added an in-page Back to Inventory control on the stock entry screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccbd4d1e4483238fbf4e81d8ffb1d5