### PR TITLE
Add persistent notifications and profile modal

### DIFF
--- a/dgz_motorshop_system/assets/css/dashboard.css
+++ b/dgz_motorshop_system/assets/css/dashboard.css
@@ -92,52 +92,71 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 20px;
     position: sticky;
     top: 0;
     z-index: 100;
 }
 
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
 /* Notification Styles */
 .notif-menu {
     position: relative;
-    margin-right: 20px;
 }
 
 .notif-bell {
-    background: none;
-    border: none;
-    font-size: 20px;
-    cursor: pointer;
     position: relative;
-    padding: 8px;
-    color: #2c3e50;
+    height: 42px;
+    width: 42px;
+    border-radius: 50%;
+    border: none;
+    background: #f1f5f9;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #1f2933;
+    font-size: 18px;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.notif-bell:hover {
+    background: #e6edf5;
+    color: #0f172a;
 }
 
 .notif-bell .badge {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: -4px;
+    right: -4px;
     background: #e74c3c;
-    color: white;
-    border-radius: 50%;
+    color: #fff;
+    border-radius: 999px;
     padding: 2px 6px;
-    font-size: 12px;
-    font-weight: bold;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
 }
 
 .notif-dropdown {
     position: absolute;
-    top: 100%;
+    top: 52px;
     right: 0;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-    width: 300px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+    width: 320px;
     opacity: 0;
     visibility: hidden;
-    transform: translateY(10px);
-    transition: all 0.3s ease;
-    z-index: 1000;
+    transform: translateY(-8px);
+    transition: all 0.2s ease;
+    overflow: hidden;
+    z-index: 1100;
 }
 
 .notif-dropdown.show {
@@ -147,61 +166,123 @@ body {
 }
 
 .notif-head {
-    padding: 15px 20px;
-    border-bottom: 1px solid #eee;
-    font-weight: bold;
-    color: #2c3e50;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 16px 20px;
+    border-bottom: 1px solid #e5e7eb;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.notif-head i {
+    color: #2563eb;
 }
 
 .notif-list {
-    max-height: 300px;
+    max-height: 320px;
     overflow-y: auto;
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.notif-list li {
-    padding: 12px 20px;
-    border-bottom: 1px solid #f5f5f5;
+.notif-item {
+    padding: 14px 20px;
+    border-bottom: 1px solid #f1f5f9;
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.notif-item:last-child {
+    border-bottom: none;
+}
+
+.notif-item:hover {
+    background: #f8fafc;
+}
+
+.notif-item.resolved {
+    background: #f9fafb;
+}
+
+.notif-row {
+    display: flex;
     align-items: center;
+    justify-content: space-between;
+    gap: 12px;
 }
 
-.notif-list li:hover {
-    background: #f8f9fa;
+.notif-title {
+    font-weight: 600;
+    color: #1f2937;
+    font-size: 14px;
 }
 
-.n-name {
-    color: #2c3e50;
+.notif-status {
+    background: #d1fae5;
+    color: #047857;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.notif-item.resolved .notif-status {
+    background: #e5e7eb;
+    color: #374151;
+}
+
+.notif-message {
+    font-size: 13px;
+    color: #4b5563;
+}
+
+.notif-product {
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.notif-time {
+    font-size: 12px;
+    color: #9ca3af;
     font-weight: 500;
-}
-
-.n-qty {
-    color: #e74c3c;
-    font-weight: bold;
 }
 
 .notif-empty {
-    padding: 20px;
+    padding: 30px 20px;
     text-align: center;
-    color: #7f8c8d;
+    color: #6b7280;
+}
+
+.notif-empty i {
+    font-size: 26px;
+    color: #22c55e;
+    margin-bottom: 12px;
+}
+
+.notif-footer {
+    padding: 12px 20px;
+    background: #f8fafc;
+    border-top: 1px solid #e5e7eb;
 }
 
 .notif-link {
-    display: block;
-    padding: 12px 20px;
-    text-align: center;
-    background: #f8f9fa;
-    color: #3498db;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: #2563eb;
     text-decoration: none;
-    font-weight: 500;
-    border-top: 1px solid #eee;
+    font-weight: 600;
+    font-size: 13px;
 }
 
 .notif-link:hover {
-    background: #f1f1f1;
+    color: #1d4ed8;
 }
 
 .header h2 {
@@ -254,12 +335,19 @@ body {
 }
 
 .dropdown-item {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
     padding: 12px 20px;
     color: #333;
     text-decoration: none;
     transition: background 0.3s ease;
     font-size: 14px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
 }
 
 .dropdown-item:hover {
@@ -339,110 +427,6 @@ body {
     justify-content: space-between;
     align-items: center;
 }
-/* Notification bell*/
-/* Notification bell */
-.notif-menu {
-  position: relative;
-  margin-right: 12px;            /* space before user avatar */
-}
-
-.notif-bell {
-  position: relative;
-  height: 40px;
-  width: 40px;
-  border-radius: 50%;
-  border: none;
-  background: #f1f5f9;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background .2s ease;
-}
-
-.notif-bell:hover { background: #e8eef6; }
-
-.bell-icon { font-size: 18px; }
-
-.badge {
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  background: #e74c3c;
-  color: #fff;
-  border-radius: 10px;
-  padding: 2px 6px;
-  font-size: 11px;
-  font-weight: 700;
-}
-
-/* Dropdown panel (similar to your .dropdown-menu) */
-.notif-dropdown {
-  position: absolute;
-  top: 48px;
-  right: 0;
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 10px 30px rgba(0,0,0,.1);
-  width: 280px;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(-8px);
-  transition: all .2s ease;
-  overflow: hidden;
-  z-index: 1001;
-}
-
-.notif-dropdown.show {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
-}
-
-.notif-head {
-  padding: 12px 14px;
-  font-weight: 600;
-  border-bottom: 1px solid #f0f2f4;
-}
-
-.notif-empty {
-  padding: 14px;
-  color: #6b7280;
-  font-size: 14px;
-  text-align: center;
-}
-
-.notif-list {
-  list-style: none;
-  margin: 0;
-  padding: 6px 0;
-  max-height: 260px;
-  overflow-y: auto;
-}
-
-.notif-list li {
-  display: flex;
-  justify-content: space-between;
-  padding: 10px 14px;
-  border-bottom: 1px solid #f7f7f7;
-  font-size: 14px;
-}
-
-.notif-list li:last-child { border-bottom: none; }
-
-.n-name { color: #1f2937; }
-.n-qty  { color: #e74c3c; font-weight: 600; }
-
-.notif-link {
-  display: block;
-  padding: 10px 14px;
-  text-decoration: none;
-  color: #2563eb;
-  font-weight: 600;
-}
-.notif-link:hover { background: #f8fafc; }
-
-/* Notification bell*/
 .widget-title {
     font-size: 18px;
     font-weight: 600;
@@ -595,5 +579,107 @@ body {
 @media (max-width: 768px) {
     .mobile-toggle {
         display: block;
+    }
+}
+
+/* Profile modal */
+body.modal-open {
+    overflow: hidden;
+}
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.2s ease;
+    z-index: 1200;
+}
+
+.modal-overlay.show {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-content {
+    background: #ffffff;
+    width: min(420px, 100%);
+    border-radius: 16px;
+    padding: 28px;
+    box-shadow: 0 20px 50px rgba(15, 23, 42, 0.2);
+    position: relative;
+    transform: translateY(20px);
+    transition: transform 0.25s ease;
+}
+
+.modal-overlay.show .modal-content {
+    transform: translateY(0);
+}
+
+.modal-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: none;
+    border: none;
+    font-size: 18px;
+    color: #64748b;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 50%;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.modal-close:hover {
+    background: #f1f5f9;
+    color: #0f172a;
+}
+
+.profile-info {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 20px;
+}
+
+.profile-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.profile-label {
+    font-weight: 600;
+    color: #6b7280;
+    font-size: 14px;
+}
+
+.profile-value {
+    color: #1f2937;
+    font-weight: 600;
+    font-size: 14px;
+    text-align: right;
+}
+
+@media (max-width: 480px) {
+    .modal-content {
+        padding: 24px 20px;
+    }
+
+    .profile-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+    }
+
+    .profile-value {
+        text-align: left;
+        width: 100%;
     }
 }


### PR DESCRIPTION
## Summary
- persist low stock alerts in a dedicated table and show relative timestamps in the dashboard notification dropdown
- add a profile info modal that opens from the user menu instead of navigating away
- refresh notification and header styling to tighten layout and support the new modal experience

## Testing
- php -l admin/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cd905b9f58832381b054df527a41c6