### PR TITLE
Add online order management tab and secure payment handling

### DIFF
--- a/dgz_motorshop_system/admin/pos.php
+++ b/dgz_motorshop_system/admin/pos.php
@@ -2,6 +2,23 @@
 require '../config.php';
 if(empty($_SESSION['user_id'])){ header('Location: login.php'); exit; }
 $pdo = db();
+
+if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_order_status'])) {
+    $orderId = isset($_POST['order_id']) ? (int) $_POST['order_id'] : 0;
+    $newStatus = $_POST['new_status'] ?? '';
+    $allowedStatuses = ['pending','approved','completed'];
+
+    if($orderId > 0 && in_array($newStatus, $allowedStatuses, true)) {
+        $stmt = $pdo->prepare('UPDATE orders SET status = ? WHERE id = ?');
+        $stmt->execute([$newStatus, $orderId]);
+        header('Location: pos.php?status_updated=1');
+        exit;
+    }
+
+    header('Location: pos.php?status_updated=0');
+    exit;
+}
+
 $products = $pdo->query('SELECT * FROM products')->fetchAll();
 
 if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['pos_checkout'])) {
@@ -82,6 +99,21 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['pos_checkout'])) {
         exit;
     }
 }
+
+$onlineOrdersStmt = $pdo->prepare("SELECT * FROM orders WHERE payment_method IS NOT NULL AND payment_method <> 'Cash' ORDER BY created_at DESC");
+$onlineOrdersStmt->execute();
+$onlineOrders = $onlineOrdersStmt->fetchAll();
+foreach ($onlineOrders as &$onlineOrder) {
+    $details = parsePaymentProofValue($onlineOrder['payment_proof'] ?? null);
+    $onlineOrder['reference_number'] = $details['reference'];
+    $onlineOrder['proof_image'] = $details['image'];
+}
+unset($onlineOrder);
+$statusOptions = [
+    'pending' => 'Pending',
+    'approved' => 'Approved',
+    'completed' => 'Completed'
+];
 ?>
 <!doctype html>
 <html>
@@ -164,6 +196,18 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['pos_checkout'])) {
             </div>
         </header>
 
+        <div class="pos-tabs">
+            <button type="button" class="pos-tab-button active" data-target="walkinTab">
+                <i class="fas fa-store"></i>
+                POS Checkout
+            </button>
+            <button type="button" class="pos-tab-button" data-target="onlineTab">
+                <i class="fas fa-shopping-bag"></i>
+                Online Orders
+            </button>
+        </div>
+
+        <div id="walkinTab" class="tab-panel active">
         <div style="display: flex; align-items: center; gap: 0px; margin: 15px 0; flex-wrap: wrap;">
             <button type="button" id="openProductModal"
                 style="padding: 8px 18px; background: #3498db; color: #fff; border: none; border-radius: 6px; font-size: 15px; cursor: pointer;"><i
@@ -327,6 +371,97 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['pos_checkout'])) {
                 <button id="addSelectedProducts"
                     style="margin-top:14px; background:#3498db; color:#fff; border:none; border-radius:6px; font-size:15px; padding:8px 18px; cursor:pointer; width:100%;">Add
                 </button>
+            </div>
+        </div>
+        </div><!-- /#walkinTab -->
+
+        <div id="onlineTab" class="tab-panel">
+            <?php if(isset($_GET['status_updated'])): ?>
+                <?php $success = $_GET['status_updated'] === '1'; ?>
+                <div class="status-alert <?= $success ? 'success' : 'error' ?>">
+                    <i class="fas <?= $success ? 'fa-check-circle' : 'fa-exclamation-circle' ?>"></i>
+                    <?= $success ? 'Order status updated.' : 'Unable to update order status.' ?>
+                </div>
+            <?php endif; ?>
+
+            <div class="online-orders-container">
+                <table class="online-orders-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Customer</th>
+                            <th>Contact</th>
+                            <th>Total</th>
+                            <th>Reference</th>
+                            <th>Proof</th>
+                            <th>Status</th>
+                            <th>Placed</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if(empty($onlineOrders)): ?>
+                            <tr>
+                                <td colspan="8" class="empty-cell">
+                                    <i class="fas fa-inbox"></i>
+                                    No online orders yet.
+                                </td>
+                            </tr>
+                        <?php else: ?>
+                            <?php foreach($onlineOrders as $order): ?>
+                                <?php $imagePath = $order['proof_image'] ? '../' . ltrim($order['proof_image'], '/') : ''; ?>
+                                <tr>
+                                    <td>#<?= (int) $order['id'] ?></td>
+                                    <td><?= htmlspecialchars($order['customer_name'] ?? 'Customer') ?></td>
+                                    <td><?= htmlspecialchars($order['contact'] ?? 'N/A') ?></td>
+                                    <td>₱<?= number_format((float) $order['total'], 2) ?></td>
+                                    <td>
+                                        <?php if(!empty($order['reference_number'])): ?>
+                                            <span class="reference-badge"><?= htmlspecialchars($order['reference_number']) ?></span>
+                                        <?php else: ?>
+                                            <span class="muted">Not provided</span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <button type="button"
+                                            class="view-proof-btn"
+                                            data-image="<?= htmlspecialchars($imagePath) ?>"
+                                            data-reference="<?= htmlspecialchars($order['reference_number'] ?? '') ?>"
+                                            data-customer="<?= htmlspecialchars($order['customer_name'] ?? 'Customer') ?>">
+                                            <i class="fas fa-receipt"></i> View
+                                        </button>
+                                    </td>
+                                    <td>
+                                        <span class="status-badge status-<?= htmlspecialchars($order['status']) ?>"><?= htmlspecialchars(ucfirst($order['status'])) ?></span>
+                                        <form method="post" class="status-form">
+                                            <input type="hidden" name="order_id" value="<?= (int) $order['id'] ?>">
+                                            <input type="hidden" name="update_order_status" value="1">
+                                            <select name="new_status">
+                                                <?php foreach($statusOptions as $value => $label): ?>
+                                                    <option value="<?= $value ?>" <?= $order['status'] === $value ? 'selected' : '' ?>><?= $label ?></option>
+                                                <?php endforeach; ?>
+                                            </select>
+                                            <button type="submit" class="status-save">Update</button>
+                                        </form>
+                                    </td>
+                                    <td><?= date('M d, Y g:i A', strtotime($order['created_at'])) ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div id="proofModal" class="proof-modal" aria-hidden="true">
+            <div class="proof-modal-content">
+                <button type="button" class="proof-close" id="closeProofModal">&times;</button>
+                <h3 class="proof-title">Payment Proof</h3>
+                <p class="proof-reference">Reference: <span id="proofReferenceValue">Not provided</span></p>
+                <p class="proof-customer">Customer: <span id="proofCustomerName">N/A</span></p>
+                <div class="proof-image-wrapper">
+                    <img id="proofImage" src="" alt="Payment proof preview" />
+                    <div id="proofNoImage" class="proof-empty">No proof uploaded.</div>
+                </div>
             </div>
         </div>
     </main>
@@ -847,13 +982,75 @@ document.getElementById('clearPosTable').onclick = function () {
     while (table.rows.length > 1) {
         table.deleteRow(1);
     }
-    
+
     updateEmptyStateVisibility();
     localStorage.removeItem('posTable');
-    
+
     // FIXED: Recalculate totals after clearing
     recalcTotal();
 };
+
+// Tab navigation for POS and online orders
+const tabButtons = document.querySelectorAll('.pos-tab-button');
+const tabPanels = document.querySelectorAll('.tab-panel');
+tabButtons.forEach(button => {
+    button.addEventListener('click', () => {
+        tabButtons.forEach(btn => btn.classList.remove('active'));
+        tabPanels.forEach(panel => panel.classList.remove('active'));
+
+        button.classList.add('active');
+        const target = document.getElementById(button.dataset.target);
+        if (target) {
+            target.classList.add('active');
+        }
+    });
+});
+
+// Proof of payment modal logic
+const proofModal = document.getElementById('proofModal');
+const proofImage = document.getElementById('proofImage');
+const proofReferenceValue = document.getElementById('proofReferenceValue');
+const proofCustomerName = document.getElementById('proofCustomerName');
+const proofNoImage = document.getElementById('proofNoImage');
+
+function closeProofModal() {
+    proofModal.classList.remove('show');
+    proofModal.setAttribute('aria-hidden', 'true');
+    proofImage.removeAttribute('src');
+    proofImage.style.display = 'none';
+    proofNoImage.style.display = 'none';
+}
+
+document.querySelectorAll('.view-proof-btn').forEach(button => {
+    button.addEventListener('click', () => {
+        const image = button.dataset.image;
+        const reference = button.dataset.reference || '';
+        const customer = button.dataset.customer || 'Customer';
+
+        proofReferenceValue.textContent = reference !== '' ? reference : 'Not provided';
+        proofCustomerName.textContent = customer;
+
+        if (image) {
+            proofImage.src = image;
+            proofImage.style.display = 'block';
+            proofNoImage.style.display = 'none';
+        } else {
+            proofImage.removeAttribute('src');
+            proofImage.style.display = 'none';
+            proofNoImage.style.display = 'flex';
+        }
+
+        proofModal.classList.add('show');
+        proofModal.setAttribute('aria-hidden', 'false');
+    });
+});
+
+document.getElementById('closeProofModal').addEventListener('click', closeProofModal);
+proofModal.addEventListener('click', (event) => {
+    if (event.target === proofModal) {
+        closeProofModal();
+    }
+});
     </script>
     <!-- Total Sales Panel 
     <script src="../assets/js/totalPanel.js"></script>-->

--- a/dgz_motorshop_system/admin/sales.php
+++ b/dgz_motorshop_system/admin/sales.php
@@ -13,9 +13,21 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
     header('Content-Type: text/csv');
     header('Content-Disposition: attachment; filename="sales.csv"');
     $out = fopen('php://output', 'w');
-    fputcsv($out, ['ID','Customer Name','Contact','Address','Total','Payment Method','Payment Proof','Status','Created At']);
+    fputcsv($out, ['ID','Customer Name','Contact','Address','Total','Payment Method','Payment Reference','Proof Image','Status','Created At']);
     foreach($export_orders as $o) {
-        fputcsv($out, [$o['id'],$o['customer_name'],$o['contact'],$o['address'],$o['total'],$o['payment_method'],$o['payment_proof'],$o['status'],$o['created_at']]);
+        $details = parsePaymentProofValue($o['payment_proof'] ?? null);
+        fputcsv($out, [
+            $o['id'],
+            $o['customer_name'],
+            $o['contact'],
+            $o['address'],
+            $o['total'],
+            $o['payment_method'],
+            $details['reference'],
+            $details['image'],
+            $o['status'],
+            $o['created_at']
+        ]);
     }
     fclose($out);
     exit;
@@ -149,7 +161,8 @@ $end_record = min($offset + $records_per_page, $total_records);
                             <th>Address</th>
                             <th>Total</th>
                             <th>Payment Method</th>
-                            <th>Payment Proof</th>
+                            <th>Reference</th>
+                            <th>Proof</th>
                             <th>Status</th>
                             <th>Created At</th>
                         </tr>
@@ -157,7 +170,7 @@ $end_record = min($offset + $records_per_page, $total_records);
                     <tbody>
                         <?php if(empty($orders)): ?>
                         <tr>
-                            <td colspan="9" style="text-align: center; padding: 40px; color: #6b7280;">
+                            <td colspan="10" style="text-align: center; padding: 40px; color: #6b7280;">
                                 <i class="fas fa-inbox"
                                     style="font-size: 48px; margin-bottom: 10px; display: block;"></i>
                                 No sales records found.
@@ -172,7 +185,23 @@ $end_record = min($offset + $records_per_page, $total_records);
                             <td><?=htmlspecialchars($o['address'] ?? 'N/A')?></td>
                             <td>₱<?=number_format($o['total'],2)?></td>
                             <td><?=htmlspecialchars($o['payment_method'])?></td>
-                            <td><?=htmlspecialchars($o['payment_proof'] ?? 'NULL')?></td>
+                            <?php $paymentDetails = parsePaymentProofValue($o['payment_proof'] ?? null); ?>
+                            <td>
+                                <?php if(!empty($paymentDetails['reference'])): ?>
+                                    <span style="font-weight:600; color:#1d4ed8;"><?=htmlspecialchars($paymentDetails['reference'])?></span>
+                                <?php else: ?>
+                                    <span style="color:#94a3b8;">Not provided</span>
+                                <?php endif; ?>
+                            </td>
+                            <td>
+                                <?php if(!empty($paymentDetails['image'])): ?>
+                                    <a href="../<?=htmlspecialchars(ltrim($paymentDetails['image'], '/'))?>" target="_blank" style="color:#0ea5e9; font-weight:600;">
+                                        View Proof
+                                    </a>
+                                <?php else: ?>
+                                    <span style="color:#94a3b8;">No image</span>
+                                <?php endif; ?>
+                            </td>
                             <td><?=htmlspecialchars($o['status'])?></td>
                             <td><?=date('M d, Y g:i A', strtotime($o['created_at']))?></td>
                         </tr>

--- a/dgz_motorshop_system/assets/css/checkout.css
+++ b/dgz_motorshop_system/assets/css/checkout.css
@@ -76,6 +76,24 @@ body {
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
 }
 
+.form-alert {
+    background: #ffe6e6;
+    border: 1px solid #ffb3b3;
+    color: #c0392b;
+    border-radius: 12px;
+    padding: 15px 20px;
+    margin-bottom: 25px;
+}
+
+.form-alert ul {
+    margin: 10px 0 0 20px;
+    padding: 0;
+}
+
+.form-alert li {
+    margin-bottom: 6px;
+}
+
 .order-summary {
     background: white;
     border-radius: 20px;

--- a/dgz_motorshop_system/assets/css/pos.css
+++ b/dgz_motorshop_system/assets/css/pos.css
@@ -166,6 +166,51 @@ body {
     background: #fee;
 }
 
+.pos-tabs {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 20px 0 10px;
+    flex-wrap: wrap;
+}
+
+.pos-tab-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 8px;
+    border: 1px solid #dfe4ea;
+    background: #f1f2f6;
+    color: #2c3e50;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.pos-tab-button i {
+    font-size: 14px;
+}
+
+.pos-tab-button:hover {
+    background: #e2e6ea;
+}
+
+.pos-tab-button.active {
+    background: #3498db;
+    border-color: #2980b9;
+    color: #fff;
+    box-shadow: 0 6px 12px rgba(52, 152, 219, 0.25);
+}
+
+.tab-panel {
+    display: none;
+}
+
+.tab-panel.active {
+    display: block;
+}
+
 /* POS Table Container - fixed height, scrollable, for sticky header */
 .pos-table-container {
     height: 610px;
@@ -178,6 +223,245 @@ body {
     position: relative;
     isolation: isolate;
     box-shadow: 0 2px 15px rgba(0,0,0,0.05);
+}
+
+.online-orders-container {
+    margin-top: 10px;
+    background: #fff;
+    border-radius: 14px;
+    padding: 20px;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+    overflow-x: auto;
+}
+
+.online-orders-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+}
+
+.online-orders-table th,
+.online-orders-table td {
+    padding: 12px 16px;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: left;
+    font-size: 14px;
+}
+
+.online-orders-table thead th {
+    background: #f8fafc;
+    font-weight: 600;
+    color: #1e293b;
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 0.05em;
+}
+
+.online-orders-table tbody tr:hover {
+    background: #f9fbff;
+}
+
+.online-orders-table .empty-cell {
+    text-align: center;
+    padding: 40px 20px;
+    color: #94a3b8;
+    font-size: 15px;
+}
+
+.online-orders-table .empty-cell i {
+    display: block;
+    font-size: 28px;
+    margin-bottom: 8px;
+}
+
+.reference-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(52, 152, 219, 0.15);
+    color: #1971c2;
+    font-weight: 600;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+}
+
+.muted {
+    color: #94a3b8;
+    font-size: 13px;
+}
+
+.view-proof-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 1px solid #3498db;
+    border-radius: 8px;
+    background: rgba(52, 152, 219, 0.08);
+    color: #1d4ed8;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.view-proof-btn:hover {
+    background: #3498db;
+    color: #fff;
+}
+
+.status-badge {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.status-badge.status-pending {
+    background: rgba(249, 115, 22, 0.15);
+    color: #c2410c;
+}
+
+.status-badge.status-approved {
+    background: rgba(34, 197, 94, 0.15);
+    color: #15803d;
+}
+
+.status-badge.status-completed {
+    background: rgba(59, 130, 246, 0.15);
+    color: #1d4ed8;
+}
+
+.status-form {
+    margin-top: 8px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.status-form select {
+    border: 1px solid #dfe4ea;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+}
+
+.status-save {
+    background: #1abc9c;
+    border: none;
+    border-radius: 6px;
+    color: #fff;
+    font-weight: 600;
+    padding: 6px 12px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.status-save:hover {
+    background: #16a085;
+}
+
+.status-alert {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    border-radius: 10px;
+    margin-bottom: 15px;
+    font-weight: 600;
+}
+
+.status-alert.success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #15803d;
+}
+
+.status-alert.error {
+    background: rgba(248, 113, 113, 0.15);
+    color: #b91c1c;
+}
+
+.status-alert i {
+    font-size: 16px;
+}
+
+.proof-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    padding: 20px;
+}
+
+.proof-modal.show {
+    display: flex;
+}
+
+.proof-modal-content {
+    background: #fff;
+    border-radius: 16px;
+    padding: 24px;
+    max-width: 420px;
+    width: 100%;
+    position: relative;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.2);
+}
+
+.proof-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #64748b;
+}
+
+.proof-title {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 12px;
+    color: #0f172a;
+}
+
+.proof-reference,
+.proof-customer {
+    margin-bottom: 8px;
+    color: #334155;
+    font-size: 14px;
+}
+
+.proof-image-wrapper {
+    margin-top: 16px;
+    background: #f8fafc;
+    border-radius: 12px;
+    min-height: 260px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.proof-image-wrapper img {
+    max-width: 100%;
+    max-height: 320px;
+    object-fit: contain;
+    display: none;
+}
+
+.proof-empty {
+    display: none;
+    color: #94a3b8;
+    font-size: 14px;
+    text-align: center;
+    padding: 20px;
 }
 
 /* UPDATED: Fixed table layout for consistent column widths */

--- a/dgz_motorshop_system/checkout.php
+++ b/dgz_motorshop_system/checkout.php
@@ -1,6 +1,8 @@
 <?php
 require 'config.php';
 $pdo = db();
+$errors = [];
+$referenceInput = '';
 
 // Handle both single product and cart scenarios
 $product_id = intval($_GET['product_id'] ?? 0);
@@ -55,57 +57,108 @@ if (empty($cartItems)) {
 
 // Process the order when form is submitted
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
-    $customer_name = $_POST['customer_name'];
-    $contact = $_POST['contact'];
-    $address = $_POST['address'];
-    $payment_method = $_POST['payment_method'];
+    $customer_name = trim($_POST['customer_name']);
+    $contact = trim($_POST['contact']);
+    $address = trim($_POST['address']);
+    $payment_method = $_POST['payment_method'] ?? '';
+    $referenceInput = trim($_POST['reference_number'] ?? '');
     $proof_path = null;
-    
-    if (!empty($_FILES['proof']['tmp_name'])) {
-        if (!is_dir('uploads')) mkdir('uploads', 0777, true);
-        $fn = 'uploads/' . time() . '_' . basename($_FILES['proof']['name']);
-        move_uploaded_file($_FILES['proof']['tmp_name'], $fn);
-        $proof_path = $fn;
+
+    $referenceNumber = preg_replace('/[^A-Za-z0-9\- ]/', '', $referenceInput);
+    $referenceNumber = strtoupper(substr($referenceNumber, 0, 50));
+    if ($referenceNumber === '') {
+        $errors[] = 'Reference number is required.';
     }
-    
+
+    if ($payment_method === '') {
+        $errors[] = 'Please select a payment method.';
+    }
+
+    if (!empty($_FILES['proof']['tmp_name'])) {
+        if ($_FILES['proof']['error'] !== UPLOAD_ERR_OK) {
+            $errors[] = 'Unable to upload the proof of payment. Please try again.';
+        } else {
+            $allowed = [
+                'image/jpeg' => 'jpg',
+                'image/png' => 'png',
+                'image/gif' => 'gif',
+                'image/webp' => 'webp',
+            ];
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+            $mime = $finfo ? finfo_file($finfo, $_FILES['proof']['tmp_name']) : null;
+            if ($finfo) {
+                finfo_close($finfo);
+            }
+
+            if (!$mime || !isset($allowed[$mime])) {
+                $errors[] = 'Please upload a valid image (JPG, PNG, GIF, or WEBP).';
+            } else {
+                if (!is_dir('uploads')) {
+                    mkdir('uploads', 0775, true);
+                }
+                try {
+                    $random = bin2hex(random_bytes(8));
+                } catch (Exception $e) {
+                    $random = time();
+                }
+                $filename = sprintf('uploads/%s.%s', $random, $allowed[$mime]);
+                if (!move_uploaded_file($_FILES['proof']['tmp_name'], $filename)) {
+                    $errors[] = 'Failed to save the uploaded proof of payment.';
+                } else {
+                    $proof_path = $filename;
+                }
+            }
+        }
+    }
+
     // Calculate total from cart items
     $total = 0;
     foreach ($cartItems as $item) {
         $total += $item['price'] * $item['quantity'];
     }
-    
-    // Insert order
-    $stmt = $pdo->prepare('INSERT INTO orders (customer_name, contact, address, total, payment_method, payment_proof, status) VALUES (?, ?, ?, ?, ?, ?, ?)');
-    $stmt->execute([$customer_name, $contact, $address, $total, $payment_method, $proof_path, 'pending']);
-    $order_id = $pdo->lastInsertId();
-    
-    // Insert order items and update stock
-    foreach ($cartItems as $item) {
-        $product = $pdo->prepare('SELECT * FROM products WHERE id = ?');
-        $product->execute([$item['id']]);
-        $p = $product->fetch();
-        
-        if ($p && $item['quantity'] <= $p['quantity']) {
-            $stmt2 = $pdo->prepare('INSERT INTO order_items (order_id, product_id, qty, price) VALUES (?, ?, ?, ?)');
-            $stmt2->execute([$order_id, $item['id'], $item['quantity'], $item['price']]);
-            
-            // Decrease stock
-            $pdo->prepare('UPDATE products SET quantity = quantity - ? WHERE id = ?')->execute([$item['quantity'], $item['id']]);
-        }
+
+    $paymentData = json_encode([
+        'reference' => $referenceNumber,
+        'image' => $proof_path,
+    ], JSON_UNESCAPED_SLASHES);
+
+    if ($paymentData === false || strlen($paymentData) > 250) {
+        $errors[] = 'Payment details are too long to be saved. Please try again.';
     }
-    
-    // Clear cart using JavaScript
-    echo '<script>localStorage.removeItem("cartItems"); localStorage.removeItem("cartCount");</script>';
-    
-    // Success message
-    echo '<div style="max-width: 600px; margin: 50px auto; background: white; padding: 40px; border-radius: 20px; box-shadow: 0 20px 40px rgba(0,0,0,0.1); text-align: center;">';
-    echo '<i class="fas fa-check-circle" style="font-size: 48px; color: #00b894; margin-bottom: 20px;"></i>';
-    echo '<h2 style="color: #2d3436; margin-bottom: 20px;">Order Placed Successfully!</h2>';
-    echo '<p style="color: #636e72; margin-bottom: 10px;">Order ID: <strong>' . $order_id . '</strong></p>';
-    echo '<p style="color: #636e72; margin-bottom: 30px;">Status: <span style="background: #fdcb6e; padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 600;">Pending</span></p>';
-    echo '<a href="index.php" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; padding: 15px 30px; border-radius: 8px; font-weight: 600;">Back to Shop</a>';
-    echo '</div>';
-    exit;
+
+    if (empty($errors)) {
+        $stmt = $pdo->prepare('INSERT INTO orders (customer_name, contact, address, total, payment_method, payment_proof, status) VALUES (?, ?, ?, ?, ?, ?, ?)');
+        $stmt->execute([$customer_name, $contact, $address, $total, $payment_method, $paymentData, 'pending']);
+        $order_id = $pdo->lastInsertId();
+
+        // Insert order items and update stock
+        foreach ($cartItems as $item) {
+            $product = $pdo->prepare('SELECT * FROM products WHERE id = ?');
+            $product->execute([$item['id']]);
+            $p = $product->fetch();
+
+            if ($p && $item['quantity'] <= $p['quantity']) {
+                $stmt2 = $pdo->prepare('INSERT INTO order_items (order_id, product_id, qty, price) VALUES (?, ?, ?, ?)');
+                $stmt2->execute([$order_id, $item['id'], $item['quantity'], $item['price']]);
+
+                // Decrease stock
+                $pdo->prepare('UPDATE products SET quantity = quantity - ? WHERE id = ?')->execute([$item['quantity'], $item['id']]);
+            }
+        }
+
+        // Clear cart using JavaScript
+        echo '<script>localStorage.removeItem("cartItems"); localStorage.removeItem("cartCount");</script>';
+
+        // Success message
+        echo '<div style="max-width: 600px; margin: 50px auto; background: white; padding: 40px; border-radius: 20px; box-shadow: 0 20px 40px rgba(0,0,0,0.1); text-align: center;">';
+        echo '<i class="fas fa-check-circle" style="font-size: 48px; color: #00b894; margin-bottom: 20px;"></i>';
+        echo '<h2 style="color: #2d3436; margin-bottom: 20px;">Order Placed Successfully!</h2>';
+        echo '<p style="color: #636e72; margin-bottom: 10px;">Order ID: <strong>' . $order_id . '</strong></p>';
+        echo '<p style="color: #636e72; margin-bottom: 30px;">Status: <span style="background: #fdcb6e; padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 600;">Pending</span></p>';
+        echo '<a href="index.php" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; padding: 15px 30px; border-radius: 8px; font-weight: 600;">Back to Shop</a>';
+        echo '</div>';
+        exit;
+    }
 }
 
 // Show checkout form
@@ -134,6 +187,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
     <div class="container">
         <!-- Left Column - Checkout Form -->
         <div class="checkout-form">
+            <?php if (!empty($errors)): ?>
+            <div class="form-alert">
+                <strong>We couldn't process your order:</strong>
+                <ul>
+                    <?php foreach ($errors as $error): ?>
+                        <li><?= htmlspecialchars($error) ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+            <?php endif; ?>
             <form method="post" enctype="multipart/form-data">
                 <input type="hidden" name="cart" value='<?= htmlspecialchars(json_encode($cartItems)) ?>'>
                 
@@ -144,7 +207,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
                         Contact
                     </h2>
                     <div class="form-group">
-                        <input type="text" name="contact" placeholder="Mobile No. or Email" required>
+                        <input type="text" name="contact" placeholder="Mobile No. or Email" value="<?= htmlspecialchars($_POST['contact'] ?? '') ?>" required>
                     </div>
                 </div>
 
@@ -157,25 +220,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
                     <div class="form-row">
                         <div class="form-group">
                             <label>First name</label>
-                            <input type="text" name="customer_name" required>
+                            <input type="text" name="customer_name" value="<?= htmlspecialchars($_POST['customer_name'] ?? '') ?>" required>
                         </div>
                         <div class="form-group">
                             <label>Last name</label>
-                            <input type="text" name="last_name">
+                            <input type="text" name="last_name" value="<?= htmlspecialchars($_POST['last_name'] ?? '') ?>">
                         </div>
                     </div>
                     <div class="form-group">
                         <label>Address</label>
-                        <textarea name="address" placeholder="Street address, apartment, suite, etc." required></textarea>
+                        <textarea name="address" placeholder="Street address, apartment, suite, etc." required><?= htmlspecialchars($_POST['address'] ?? '') ?></textarea>
                     </div>
                     <div class="form-row">
                         <div class="form-group">
                             <label>Postal code</label>
-                            <input type="text" name="postal_code">
+                            <input type="text" name="postal_code" value="<?= htmlspecialchars($_POST['postal_code'] ?? '') ?>">
                         </div>
                         <div class="form-group">
                             <label>City</label>
-                            <input type="text" name="city">
+                            <input type="text" name="city" value="<?= htmlspecialchars($_POST['city'] ?? '') ?>">
                         </div>
                     </div>
                 </div>
@@ -189,7 +252,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
                     <div class="payment-methods">
                         
                         <div class="payment-option">
-                            <input type="radio" name="payment_method" value="GCash" id="gcash">
+                            <input type="radio" name="payment_method" value="GCash" id="gcash" <?= (($_POST['payment_method'] ?? 'GCash') === 'GCash') ? 'checked' : '' ?>>
                             <label for="gcash">
                                 <i class="fas fa-mobile-alt"></i>&nbsp; GCash
                             </label>
@@ -201,7 +264,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
                             <i class="fas fa-qrcode" style="font-size: 48px; color: #636e72;"></i>
                         </div>
                     </div>
-                    
+
+                    <div class="form-group">
+                        <label for="reference_number">Reference Number</label>
+                        <input type="text" name="reference_number" id="reference_number" maxlength="50" value="<?= htmlspecialchars($referenceInput) ?>" placeholder="e.g. GCASH123456" required>
+                    </div>
+
                     <div class="file-upload">
                         <input type="file" name="proof" id="proof" accept="image/*">
                         <label for="proof">

--- a/dgz_motorshop_system/config.php
+++ b/dgz_motorshop_system/config.php
@@ -13,5 +13,34 @@ function db() {
     ]);
     return $pdo;
 }
+/**
+ * Normalize payment proof information so callers can reliably access
+ * the reference number and optional image path.
+ */
+function parsePaymentProofValue($value) {
+    $details = [
+        'reference' => null,
+        'image' => null,
+    ];
+
+    if (empty($value)) {
+        return $details;
+    }
+
+    $decoded = json_decode($value, true);
+    if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+        if (!empty($decoded['reference'])) {
+            $details['reference'] = (string) $decoded['reference'];
+        }
+        if (!empty($decoded['image'])) {
+            $details['image'] = (string) $decoded['image'];
+        }
+    } else {
+        // Legacy orders stored only the uploaded image path.
+        $details['image'] = (string) $value;
+    }
+
+    return $details;
+}
 session_start();
 ?>


### PR DESCRIPTION
## Summary
- add a helper to normalize payment proof data so both reference numbers and image paths are exposed consistently
- secure the checkout flow by validating uploads, capturing a required reference number, and storing payment proof details as structured data
- extend the POS page with an online orders tab that shows payment proofs, constrains preview sizes, and lets staff update order statuses
- refresh related styling and sales reporting to surface the new payment reference information

## Testing
- php -l dgz_motorshop_system/config.php
- php -l dgz_motorshop_system/checkout.php
- php -l dgz_motorshop_system/admin/pos.php
- php -l dgz_motorshop_system/admin/sales.php

------
https://chatgpt.com/codex/tasks/task_e_68d0c6a60080832394ebc9e52eddc82a