### PR TITLE
Fix POS approval flow and add reusable profile modal

### DIFF
--- a/dgz_motorshop_system/admin/inventory.php
+++ b/dgz_motorshop_system/admin/inventory.php
@@ -28,6 +28,34 @@ $inventoryNotificationData = loadInventoryNotifications($pdo);
 $inventoryNotifications = $inventoryNotificationData['notifications'];
 $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 
+// Fetch the authenticated user's information for the profile modal
+$current_user = null;
+try {
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $current_user = $stmt->fetch();
+} catch (Exception $e) {
+    error_log('User lookup failed: ' . $e->getMessage());
+}
+
+function format_profile_date(?string $datetime): string
+{
+    if (!$datetime) {
+        return 'N/A';
+    }
+
+    $timestamp = strtotime($datetime);
+    if ($timestamp === false) {
+        return 'N/A';
+    }
+
+    return date('F j, Y g:i A', $timestamp);
+}
+
+$profile_name = $current_user['name'] ?? 'N/A';
+$profile_role = !empty($current_user['role']) ? ucfirst($current_user['role']) : 'N/A';
+$profile_created = format_profile_date($current_user['created_at'] ?? null);
+
 // Handle restock request submission (available to any authenticated user)
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['submit_restock_request'])) {
     $restockFormData = [
@@ -660,9 +688,9 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
                         <i class="fas fa-user"></i>
                     </div>
                     <div class="dropdown-menu" id="userDropdown">
-                        <a href="profile.php" class="dropdown-item">
+                        <button type="button" class="dropdown-item" id="profileTrigger">
                             <i class="fas fa-user-cog"></i> Profile
-                        </a>
+                        </button>
                         <a href="settings.php" class="dropdown-item">
                             <i class="fas fa-cog"></i> Settings
                         </a>
@@ -1060,6 +1088,30 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
             sidebar.classList.toggle('mobile-open');
         }
 
+        const profileButton = document.getElementById('profileTrigger');
+        const profileModal = document.getElementById('profileModal');
+        const profileModalClose = document.getElementById('profileModalClose');
+
+        function openProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.add('show');
+            profileModal.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('modal-open');
+        }
+
+        function closeProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.remove('show');
+            profileModal.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('modal-open');
+        }
+
         // Close dropdown when clicking outside
         document.addEventListener('click', function (event) {
             const userMenu = document.querySelector('.user-menu');
@@ -1067,6 +1119,29 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
 
             if (!userMenu.contains(event.target)) {
                 dropdown.classList.remove('show');
+            }
+        });
+
+        profileButton?.addEventListener('click', function(event) {
+            event.preventDefault();
+            const dropdown = document.getElementById('userDropdown');
+            dropdown?.classList.remove('show');
+            openProfileModal();
+        });
+
+        profileModalClose?.addEventListener('click', function() {
+            closeProfileModal();
+        });
+
+        profileModal?.addEventListener('click', function(event) {
+            if (event.target === profileModal) {
+                closeProfileModal();
+            }
+        });
+
+        document.addEventListener('keydown', function(event) {
+            if (event.key === 'Escape' && profileModal?.classList.contains('show')) {
+                closeProfileModal();
             }
         });
 
@@ -1298,6 +1373,28 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
             }
         });
     </script>
+    <div class="modal-overlay" id="profileModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="profileModalTitle">
+            <button type="button" class="modal-close" id="profileModalClose" aria-label="Close profile information">
+                <i class="fas fa-times"></i>
+            </button>
+            <h3 id="profileModalTitle">Profile information</h3>
+            <div class="profile-info">
+                <div class="profile-row">
+                    <span class="profile-label">Name</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_name) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Role</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_role) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Date created</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_created) ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
     <script src="../assets/js/notifications.js"></script>
 </body>
 </html>

--- a/dgz_motorshop_system/admin/pos.php
+++ b/dgz_motorshop_system/admin/pos.php
@@ -16,6 +16,34 @@ $inventoryNotificationData = loadInventoryNotifications($pdo);
 $inventoryNotifications = $inventoryNotificationData['notifications'];
 $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 
+// Fetch the authenticated user's information for the profile modal
+$current_user = null;
+try {
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $current_user = $stmt->fetch();
+} catch (Exception $e) {
+    error_log('User lookup failed: ' . $e->getMessage());
+}
+
+function format_profile_date(?string $datetime): string
+{
+    if (!$datetime) {
+        return 'N/A';
+    }
+
+    $timestamp = strtotime($datetime);
+    if ($timestamp === false) {
+        return 'N/A';
+    }
+
+    return date('F j, Y g:i A', $timestamp);
+}
+
+$profile_name = $current_user['name'] ?? 'N/A';
+$profile_role = !empty($current_user['role']) ? ucfirst($current_user['role']) : 'N/A';
+$profile_created = format_profile_date($current_user['created_at'] ?? null);
+
 $allowedStatuses = ['pending', 'approved', 'completed'];
 
 /**
@@ -49,12 +77,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_order_status']
         $currentOrder = $orderStmt->fetch();
 
         if ($currentOrder) {
-            $currentStatus = strtolower((string) ($currentOrder['status'] ?? 'pending'));
+            $currentStatus = strtolower((string) ($currentOrder['status'] ?? ''));
+            if ($currentStatus === '') {
+                $currentStatus = 'pending';
+            }
             $transitions = [
                 'pending' => ['approved', 'completed'],
                 'approved' => ['completed'],
                 'completed' => [],
             ];
+
+            if (!array_key_exists($currentStatus, $transitions)) {
+                $currentStatus = 'pending';
+            }
 
             $allowedNext = $transitions[$currentStatus] ?? [];
 
@@ -364,9 +399,9 @@ if ($receiptDataJson === false) {
                         <i class="fas fa-user"></i>
                     </button>
                     <div class="dropdown-menu" id="userDropdown">
-                        <a href="profile.php" class="dropdown-item">
+                        <button type="button" class="dropdown-item" id="profileTrigger">
                             <i class="fas fa-user-cog"></i> Profile
-                        </a>
+                        </button>
                         <a href="settings.php" class="dropdown-item">
                             <i class="fas fa-cog"></i> Settings
                         </a>
@@ -553,6 +588,29 @@ if ($receiptDataJson === false) {
         </div>
     </main>
 
+    <div class="modal-overlay" id="profileModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="profileModalTitle">
+            <button type="button" class="modal-close" id="profileModalClose" aria-label="Close profile information">
+                <i class="fas fa-times"></i>
+            </button>
+            <h3 id="profileModalTitle">Profile information</h3>
+            <div class="profile-info">
+                <div class="profile-row">
+                    <span class="profile-label">Name</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_name) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Role</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_role) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Date created</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_created) ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div id="productModal" class="modal-overlay" style="display:none;">
         <div class="modal-content large-modal">
             <button id="closeProductModal" type="button" class="modal-close">&times;</button>
@@ -655,6 +713,9 @@ if ($receiptDataJson === false) {
             const posEmptyState = document.getElementById('posEmptyState');
             const amountReceivedInput = document.getElementById('amountReceived');
             const settlePaymentButton = document.getElementById('settlePaymentButton');
+            const profileButton = document.getElementById('profileTrigger');
+            const profileModal = document.getElementById('profileModal');
+            const profileModalClose = document.getElementById('profileModalClose');
 
             const totals = {
                 sales: document.getElementById('salesTotalAmount'),
@@ -689,6 +750,26 @@ if ($receiptDataJson === false) {
             const tabPanels = {
                 walkin: document.getElementById('walkinTab'),
                 online: document.getElementById('onlineTab'),
+            };
+
+            const openProfileModal = () => {
+                if (!profileModal) {
+                    return;
+                }
+
+                profileModal.classList.add('show');
+                profileModal.setAttribute('aria-hidden', 'false');
+                document.body.classList.add('modal-open');
+            };
+
+            const closeProfileModal = () => {
+                if (!profileModal) {
+                    return;
+                }
+
+                profileModal.classList.remove('show');
+                profileModal.setAttribute('aria-hidden', 'true');
+                document.body.classList.remove('modal-open');
             };
 
             function formatPeso(value) {
@@ -1263,6 +1344,28 @@ if ($receiptDataJson === false) {
             document.addEventListener('click', (event) => {
                 if (userMenu && userDropdown && !userMenu.contains(event.target)) {
                     userDropdown.classList.remove('show');
+                }
+            });
+
+            profileButton?.addEventListener('click', (event) => {
+                event.preventDefault();
+                userDropdown?.classList.remove('show');
+                openProfileModal();
+            });
+
+            profileModalClose?.addEventListener('click', () => {
+                closeProfileModal();
+            });
+
+            profileModal?.addEventListener('click', (event) => {
+                if (event.target === profileModal) {
+                    closeProfileModal();
+                }
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && profileModal?.classList.contains('show')) {
+                    closeProfileModal();
                 }
             });
 

--- a/dgz_motorshop_system/admin/products.php
+++ b/dgz_motorshop_system/admin/products.php
@@ -160,6 +160,34 @@ $inventoryNotificationData = loadInventoryNotifications($pdo);
 $inventoryNotifications = $inventoryNotificationData['notifications'];
 $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 
+// Fetch the authenticated user's information for the profile modal
+$current_user = null;
+try {
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $current_user = $stmt->fetch();
+} catch (Exception $e) {
+    error_log('User lookup failed: ' . $e->getMessage());
+}
+
+function format_profile_date(?string $datetime): string
+{
+    if (!$datetime) {
+        return 'N/A';
+    }
+
+    $timestamp = strtotime($datetime);
+    if ($timestamp === false) {
+        return 'N/A';
+    }
+
+    return date('F j, Y g:i A', $timestamp);
+}
+
+$profile_name = $current_user['name'] ?? 'N/A';
+$profile_role = !empty($current_user['role']) ? ucfirst($current_user['role']) : 'N/A';
+$profile_created = format_profile_date($current_user['created_at'] ?? null);
+
 if(isset($_GET['delete'])) {
     $product_id = intval($_GET['delete']);
     
@@ -411,9 +439,9 @@ $suppliers = $pdo->query('SELECT DISTINCT supplier FROM products WHERE supplier 
                         <i class="fas fa-user"></i>
                     </div>
                     <div class="dropdown-menu" id="userDropdown">
-                        <a href="profile.php" class="dropdown-item">
+                        <button type="button" class="dropdown-item" id="profileTrigger">
                             <i class="fas fa-user-cog"></i> Profile
-                        </a>
+                        </button>
                         <a href="settings.php" class="dropdown-item">
                             <i class="fas fa-cog"></i> Settings
                         </a>
@@ -801,6 +829,30 @@ $suppliers = $pdo->query('SELECT DISTINCT supplier FROM products WHERE supplier 
             sidebar.classList.toggle('mobile-open');
         }
 
+        const profileButton = document.getElementById('profileTrigger');
+        const profileModal = document.getElementById('profileModal');
+        const profileModalClose = document.getElementById('profileModalClose');
+
+        function openProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.add('show');
+            profileModal.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('modal-open');
+        }
+
+        function closeProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.remove('show');
+            profileModal.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('modal-open');
+        }
+
         // Close dropdown when clicking outside
         document.addEventListener('click', function (event) {
             const userMenu = document.querySelector('.user-menu');
@@ -808,6 +860,29 @@ $suppliers = $pdo->query('SELECT DISTINCT supplier FROM products WHERE supplier 
 
             if (!userMenu.contains(event.target)) {
                 dropdown.classList.remove('show');
+            }
+        });
+
+        profileButton?.addEventListener('click', function(event) {
+            event.preventDefault();
+            const dropdown = document.getElementById('userDropdown');
+            dropdown?.classList.remove('show');
+            openProfileModal();
+        });
+
+        profileModalClose?.addEventListener('click', function() {
+            closeProfileModal();
+        });
+
+        profileModal?.addEventListener('click', function(event) {
+            if (event.target === profileModal) {
+                closeProfileModal();
+            }
+        });
+
+        document.addEventListener('keydown', function(event) {
+            if (event.key === 'Escape' && profileModal?.classList.contains('show')) {
+                closeProfileModal();
             }
         });
 
@@ -907,6 +982,29 @@ $suppliers = $pdo->query('SELECT DISTINCT supplier FROM products WHERE supplier 
             if (e.target === this) this.style.display = 'none';
         });
     </script>
+
+    <div class="modal-overlay" id="profileModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="profileModalTitle">
+            <button type="button" class="modal-close" id="profileModalClose" aria-label="Close profile information">
+                <i class="fas fa-times"></i>
+            </button>
+            <h3 id="profileModalTitle">Profile information</h3>
+            <div class="profile-info">
+                <div class="profile-row">
+                    <span class="profile-label">Name</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_name) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Role</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_role) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Date created</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_created) ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <script src="../assets/js/notifications.js"></script>
 

--- a/dgz_motorshop_system/admin/sales.php
+++ b/dgz_motorshop_system/admin/sales.php
@@ -42,6 +42,34 @@ $inventoryNotificationData = loadInventoryNotifications($pdo);
 $inventoryNotifications = $inventoryNotificationData['notifications'];
 $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 
+// Fetch the authenticated user's information for the profile modal
+$current_user = null;
+try {
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $current_user = $stmt->fetch();
+} catch (Exception $e) {
+    error_log('User lookup failed: ' . $e->getMessage());
+}
+
+function format_profile_date(?string $datetime): string
+{
+    if (!$datetime) {
+        return 'N/A';
+    }
+
+    $timestamp = strtotime($datetime);
+    if ($timestamp === false) {
+        return 'N/A';
+    }
+
+    return date('F j, Y g:i A', $timestamp);
+}
+
+$profile_name = $current_user['name'] ?? 'N/A';
+$profile_role = !empty($current_user['role']) ? ucfirst($current_user['role']) : 'N/A';
+$profile_created = format_profile_date($current_user['created_at'] ?? null);
+
 // Pagination variables
 $records_per_page = 20;
 $current_page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
@@ -101,9 +129,9 @@ $end_record = min($offset + $records_per_page, $total_records);
                         <i class="fas fa-user"></i>
                     </div>
                     <div class="dropdown-menu" id="userDropdown">
-                        <a href="profile.php" class="dropdown-item">
+                        <button type="button" class="dropdown-item" id="profileTrigger">
                             <i class="fas fa-user-cog"></i> Profile
-                        </a>
+                        </button>
                         <a href="settings.php" class="dropdown-item">
                             <i class="fas fa-cog"></i> Settings
                         </a>
@@ -384,6 +412,29 @@ $end_record = min($offset + $records_per_page, $total_records);
         </div>
     </div>
 
+    <div class="modal-overlay" id="profileModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="profileModalTitle">
+            <button type="button" class="modal-close" id="profileModalClose" aria-label="Close profile information">
+                <i class="fas fa-times"></i>
+            </button>
+            <h3 id="profileModalTitle">Profile information</h3>
+            <div class="profile-info">
+                <div class="profile-row">
+                    <span class="profile-label">Name</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_name) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Role</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_role) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Date created</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_created) ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script>
         // sales trend piechart
         (function(){
@@ -619,6 +670,30 @@ $end_record = min($offset + $records_per_page, $total_records);
             sidebar.classList.toggle('mobile-open');
         }
 
+        const profileButton = document.getElementById('profileTrigger');
+        const profileModal = document.getElementById('profileModal');
+        const profileModalClose = document.getElementById('profileModalClose');
+
+        function openProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.add('show');
+            profileModal.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('modal-open');
+        }
+
+        function closeProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.remove('show');
+            profileModal.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('modal-open');
+        }
+
         // Close dropdown when clicking outside
         document.addEventListener('click', function (event) {
             const userMenu = document.querySelector('.user-menu');
@@ -626,6 +701,29 @@ $end_record = min($offset + $records_per_page, $total_records);
 
             if (!userMenu.contains(event.target)) {
                 dropdown.classList.remove('show');
+            }
+        });
+
+        profileButton?.addEventListener('click', function(event) {
+            event.preventDefault();
+            const dropdown = document.getElementById('userDropdown');
+            dropdown?.classList.remove('show');
+            openProfileModal();
+        });
+
+        profileModalClose?.addEventListener('click', function() {
+            closeProfileModal();
+        });
+
+        profileModal?.addEventListener('click', function(event) {
+            if (event.target === profileModal) {
+                closeProfileModal();
+            }
+        });
+
+        document.addEventListener('keydown', function(event) {
+            if (event.key === 'Escape' && profileModal?.classList.contains('show')) {
+                closeProfileModal();
             }
         });
 

--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -11,6 +11,34 @@ $inventoryNotificationData = loadInventoryNotifications($pdo);
 $inventoryNotifications = $inventoryNotificationData['notifications'];
 $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 
+// Fetch the authenticated user's information for the profile modal
+$current_user = null;
+try {
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $current_user = $stmt->fetch();
+} catch (Exception $e) {
+    error_log('User lookup failed: ' . $e->getMessage());
+}
+
+function format_profile_date(?string $datetime): string
+{
+    if (!$datetime) {
+        return 'N/A';
+    }
+
+    $timestamp = strtotime($datetime);
+    if ($timestamp === false) {
+        return 'N/A';
+    }
+
+    return date('F j, Y g:i A', $timestamp);
+}
+
+$profile_name = $current_user['name'] ?? 'N/A';
+$profile_role = !empty($current_user['role']) ? ucfirst($current_user['role']) : 'N/A';
+$profile_created = format_profile_date($current_user['created_at'] ?? null);
+
 // Handle stock entry submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_stock'])) {
     $product_id = $_POST['product_id'] ?? '';
@@ -90,9 +118,9 @@ $recent_entries = $pdo->query("
                         <i class="fas fa-user"></i>
                     </div>
                     <div class="dropdown-menu" id="userDropdown">
-                        <a href="profile.php" class="dropdown-item">
+                        <button type="button" class="dropdown-item" id="profileTrigger">
                             <i class="fas fa-user-cog"></i> Profile
-                        </a>
+                        </button>
                         <a href="settings.php" class="dropdown-item">
                             <i class="fas fa-cog"></i> Settings
                         </a>
@@ -205,6 +233,29 @@ $recent_entries = $pdo->query("
         </div>
     </main>
 
+    <div class="modal-overlay" id="profileModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="profileModalTitle">
+            <button type="button" class="modal-close" id="profileModalClose" aria-label="Close profile information">
+                <i class="fas fa-times"></i>
+            </button>
+            <h3 id="profileModalTitle">Profile information</h3>
+            <div class="profile-info">
+                <div class="profile-row">
+                    <span class="profile-label">Name</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_name) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Role</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_role) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Date created</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_created) ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script>
         // Toggle user dropdown
         function toggleDropdown() {
@@ -218,6 +269,30 @@ $recent_entries = $pdo->query("
             sidebar.classList.toggle('mobile-open');
         }
 
+        const profileButton = document.getElementById('profileTrigger');
+        const profileModal = document.getElementById('profileModal');
+        const profileModalClose = document.getElementById('profileModalClose');
+
+        function openProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.add('show');
+            profileModal.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('modal-open');
+        }
+
+        function closeProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.remove('show');
+            profileModal.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('modal-open');
+        }
+
         // Close dropdown when clicking outside
         document.addEventListener('click', function(event) {
             const userMenu = document.querySelector('.user-menu');
@@ -225,6 +300,29 @@ $recent_entries = $pdo->query("
 
             if (!userMenu.contains(event.target)) {
                 dropdown.classList.remove('show');
+            }
+        });
+
+        profileButton?.addEventListener('click', function(event) {
+            event.preventDefault();
+            const dropdown = document.getElementById('userDropdown');
+            dropdown?.classList.remove('show');
+            openProfileModal();
+        });
+
+        profileModalClose?.addEventListener('click', function() {
+            closeProfileModal();
+        });
+
+        profileModal?.addEventListener('click', function(event) {
+            if (event.target === profileModal) {
+                closeProfileModal();
+            }
+        });
+
+        document.addEventListener('keydown', function(event) {
+            if (event.key === 'Escape' && profileModal?.classList.contains('show')) {
+                closeProfileModal();
             }
         });
 

--- a/dgz_motorshop_system/admin/stockRequests.php
+++ b/dgz_motorshop_system/admin/stockRequests.php
@@ -16,6 +16,34 @@ $inventoryNotificationData = loadInventoryNotifications($pdo);
 $inventoryNotifications = $inventoryNotificationData['notifications'];
 $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 
+// Fetch the authenticated user's information for the profile modal
+$current_user = null;
+try {
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $current_user = $stmt->fetch();
+} catch (Exception $e) {
+    error_log('User lookup failed: ' . $e->getMessage());
+}
+
+function format_profile_date(?string $datetime): string
+{
+    if (!$datetime) {
+        return 'N/A';
+    }
+
+    $timestamp = strtotime($datetime);
+    if ($timestamp === false) {
+        return 'N/A';
+    }
+
+    return date('F j, Y g:i A', $timestamp);
+}
+
+$profile_name = $current_user['name'] ?? 'N/A';
+$profile_role = !empty($current_user['role']) ? ucfirst($current_user['role']) : 'N/A';
+$profile_created = format_profile_date($current_user['created_at'] ?? null);
+
 $flashMessage = $_SESSION['restock_flash'] ?? null;
 $flashType = $_SESSION['restock_flash_type'] ?? null;
 unset($_SESSION['restock_flash'], $_SESSION['restock_flash_type']);
@@ -166,9 +194,9 @@ function getStatusClass(string $status): string
                         <i class="fas fa-user"></i>
                     </div>
                     <div class="dropdown-menu" id="userDropdown">
-                        <a href="profile.php" class="dropdown-item">
+                        <button type="button" class="dropdown-item" id="profileTrigger">
                             <i class="fas fa-user-cog"></i> Profile
-                        </a>
+                        </button>
                         <a href="settings.php" class="dropdown-item">
                             <i class="fas fa-cog"></i> Settings
                         </a>
@@ -362,6 +390,29 @@ function getStatusClass(string $status): string
         </section>
     </main>
 
+    <div class="modal-overlay" id="profileModal" aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="profileModalTitle">
+            <button type="button" class="modal-close" id="profileModalClose" aria-label="Close profile information">
+                <i class="fas fa-times"></i>
+            </button>
+            <h3 id="profileModalTitle">Profile information</h3>
+            <div class="profile-info">
+                <div class="profile-row">
+                    <span class="profile-label">Name</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_name) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Role</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_role) ?></span>
+                </div>
+                <div class="profile-row">
+                    <span class="profile-label">Date created</span>
+                    <span class="profile-value"><?= htmlspecialchars($profile_created) ?></span>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script>
         function toggleDropdown() {
             const dropdown = document.getElementById('userDropdown');
@@ -373,11 +424,58 @@ function getStatusClass(string $status): string
             sidebar.classList.toggle('mobile-open');
         }
 
+        const profileButton = document.getElementById('profileTrigger');
+        const profileModal = document.getElementById('profileModal');
+        const profileModalClose = document.getElementById('profileModalClose');
+
+        function openProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.add('show');
+            profileModal.setAttribute('aria-hidden', 'false');
+            document.body.classList.add('modal-open');
+        }
+
+        function closeProfileModal() {
+            if (!profileModal) {
+                return;
+            }
+
+            profileModal.classList.remove('show');
+            profileModal.setAttribute('aria-hidden', 'true');
+            document.body.classList.remove('modal-open');
+        }
+
         document.addEventListener('click', function (event) {
             const userMenu = document.querySelector('.user-menu');
             const dropdown = document.getElementById('userDropdown');
             if (!userMenu.contains(event.target)) {
                 dropdown.classList.remove('show');
+            }
+        });
+
+        profileButton?.addEventListener('click', function(event) {
+            event.preventDefault();
+            const dropdown = document.getElementById('userDropdown');
+            dropdown?.classList.remove('show');
+            openProfileModal();
+        });
+
+        profileModalClose?.addEventListener('click', function() {
+            closeProfileModal();
+        });
+
+        profileModal?.addEventListener('click', function(event) {
+            if (event.target === profileModal) {
+                closeProfileModal();
+            }
+        });
+
+        document.addEventListener('keydown', function(event) {
+            if (event.key === 'Escape' && profileModal?.classList.contains('show')) {
+                closeProfileModal();
             }
         });
 


### PR DESCRIPTION
## Summary
- ensure the POS approval workflow treats blank statuses as pending so updates succeed and invoice numbers are generated
- surface the authenticated user profile modal across POS, sales, inventory, products, stock entry, stock requests, and user management screens
- wire profile dropdowns to open the modal and add the supporting markup and scripts to each page

## Testing
- php -l dgz_motorshop_system/admin/pos.php dgz_motorshop_system/admin/sales.php dgz_motorshop_system/admin/stockEntry.php dgz_motorshop_system/admin/stockRequests.php dgz_motorshop_system/admin/inventory.php dgz_motorshop_system/admin/userManagement.php dgz_motorshop_system/admin/products.php

------
https://chatgpt.com/codex/tasks/task_e_68d4f6b61638832ca8d086ad33992694