### PR TITLE
Allow admins to remove staff accounts

### DIFF
--- a/dgz_motorshop_system/assets/css/users/userManagement.css
+++ b/dgz_motorshop_system/assets/css/users/userManagement.css
@@ -140,6 +140,39 @@ html, body {
     font-weight: 600;
 }
 
+.table-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.inline-form {
+    display: inline-flex;
+    margin: 0;
+}
+
+.danger-action {
+    background: #dc2626;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 14px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: background 0.2s ease;
+}
+
+.danger-action:hover {
+    background: #b91c1c;
+}
+
+.muted {
+    color: #9ca3af;
+}
+
 .role-badge {
     display: inline-block;
     padding: 4px 10px;


### PR DESCRIPTION
## Summary
- add backend handling to allow admins to delete staff accounts from the user management page while preventing self-deletion and admin removal
- surface a remove action in the user list with confirmation prompts
- style the new action button and supporting table layout elements

## Testing
- php -l dgz_motorshop_system/admin/userManagement.php

------
https://chatgpt.com/codex/tasks/task_e_68d59a1bcbcc832c8a2b3053d5421ddf