### PR TITLE
Rebuild inventory notification time ago handling

### DIFF
--- a/dgz_motorshop_system/admin/markNotificationsRead.php
+++ b/dgz_motorshop_system/admin/markNotificationsRead.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/includes/inventory_notifications.php';
 
 header('Content-Type: application/json');
 
@@ -17,6 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 try {
     $pdo = db();
+    ensureInventoryNotificationSchema($pdo); // Keep created_at immutable before we mark rows as read.
     $stmt = $pdo->prepare("UPDATE inventory_notifications SET is_read = 1 WHERE status = 'active' AND is_read = 0");
     $stmt->execute();
 

--- a/dgz_motorshop_system/admin/partials/notification_menu.php
+++ b/dgz_motorshop_system/admin/partials/notification_menu.php
@@ -39,7 +39,7 @@ $notificationManageLink = $notificationManageLink ?? 'inventory.php';
                 <?php if (!empty($note['product_name'])) : ?>
                 <span class="notif-product"><?= htmlspecialchars($note['product_name']) ?></span>
                 <?php endif; ?>
-                <span class="notif-time"><?= htmlspecialchars(format_time_ago($note['created_at'])) ?></span>
+                <span class="notif-time"><?= htmlspecialchars($note['time_ago'] ?? '') ?></span>
             </li>
             <?php endforeach; ?>
         </ul>


### PR DESCRIPTION
## Summary
- replace the old refresh helper with a rebuilt notification service that locks schema defaults and synchronises low-stock events
- compute notification age via TIMESTAMPDIFF in SQL and expose a dedicated formatter so "time ago" survives timezone drift
- update the dropdown partial to use the preformatted time strings from the refreshed loader

## Testing
- php -l dgz_motorshop_system/admin/includes/inventory_notifications.php
- php -l dgz_motorshop_system/admin/partials/notification_menu.php

------
https://chatgpt.com/codex/tasks/task_e_68d62f002984832caf4998ee7df6147f