### PR TITLE
Add detailed period filter to dashboard top selling widget

### DIFF
--- a/dgz_motorshop_system/admin/dashboard.php
+++ b/dgz_motorshop_system/admin/dashboard.php
@@ -65,9 +65,32 @@ $topPeriodValue = $topPeriodInfo['value'];
 $topPeriodLabel = $topPeriodInfo['label'];
 $topRangeStart = $topPeriodInfo['range_start'];
 $topRangeEnd = $topPeriodInfo['range_end'];
-$topRangeDisplay = $topRangeStart === $topRangeEnd
-    ? $topRangeStart
-    : $topRangeStart . ' - ' . $topRangeEnd;
+
+function format_top_selling_range(string $startDate, string $endDate): string
+{
+    $start = DateTimeImmutable::createFromFormat('Y-m-d', $startDate) ?: null;
+    $end = DateTimeImmutable::createFromFormat('Y-m-d', $endDate) ?: null;
+
+    if (!$start) {
+        return $startDate;
+    }
+
+    if (!$end) {
+        $end = $start;
+    }
+
+    if ($start->format('Y-m-d') === $end->format('Y-m-d')) {
+        return $start->format('F j, Y');
+    }
+
+    return sprintf(
+        '%s - %s',
+        $start->format('F j, Y'),
+        $end->format('F j, Y')
+    );
+}
+
+$topRangeDisplay = format_top_selling_range($topRangeStart, $topRangeEnd);
 
 $topPickerType = 'date';
 $topPickerLabel = 'Select day';
@@ -95,7 +118,7 @@ try {
         INNER JOIN products p ON p.id = oi.product_id
         WHERE o.created_at >= :start
           AND o.created_at < :end
-          AND o.status IN ('approved', 'completed')
+          AND o.status IN ('pending', 'payment_verification', 'approved', 'completed')
         GROUP BY p.id
         ORDER BY sold DESC
         LIMIT 5

--- a/dgz_motorshop_system/admin/dashboard.php
+++ b/dgz_motorshop_system/admin/dashboard.php
@@ -217,22 +217,22 @@ $profile_created = format_profile_date($current_user['created_at'] ?? null);
         <div class="dashboard-content">
             <!-- Stats Overview -->
             <div class="stats-overview">
-                <div class="stat-card">
+                <a class="stat-card" href="sales.php">
                     <div class="stat-value"><?= intval($t['c']) ?></div>
                     <div class="stat-label">Today's Orders</div>
-                </div>
-                <div class="stat-card">
+                </a>
+                <a class="stat-card" href="sales.php">
                     <div class="stat-value">₱<?= number_format($t['s'], 2) ?></div>
                     <div class="stat-label">Today's Sales</div>
-                </div>
-                <div class="stat-card">
+                </a>
+                <a class="stat-card" href="inventory.php">
                     <div class="stat-value"><?= count($low) ?></div>
                     <div class="stat-label">Low Stock Items</div>
-                </div>
-                <div class="stat-card">
+                </a>
+                <a class="stat-card" href="sales.php">
                     <div class="stat-value"><?= count($top) ?></div>
                     <div class="stat-label">Top Products</div>
-                </div>
+                </a>
             </div>
 
             <!-- Dashboard Grid -->

--- a/dgz_motorshop_system/admin/dashboard.php
+++ b/dgz_motorshop_system/admin/dashboard.php
@@ -250,34 +250,45 @@ $profile_created = format_profile_date($current_user['created_at'] ?? null);
                             Top Selling Products
                         </h3>
                         <!-- Time Range Selector for Top Products -->
-                        <div class="period-selector">
-                            <form method="get" id="topSellingFilters" class="period-form" data-period="<?= htmlspecialchars($topPeriod) ?>" data-value="<?= htmlspecialchars($topPeriodValue) ?>" data-range="<?= htmlspecialchars($topRangeDisplay) ?>">
-                                <div class="control-group">
-                                    <label for="topSellingPeriod" class="control-label">View</label>
-                                    <select name="top_period" id="topSellingPeriod" class="period-dropdown" data-period-select>
-                                        <option value="daily" <?= $topPeriod === 'daily' ? 'selected' : '' ?>>Daily</option>
-                                        <option value="weekly" <?= $topPeriod === 'weekly' ? 'selected' : '' ?>>Weekly</option>
-                                        <option value="monthly" <?= $topPeriod === 'monthly' ? 'selected' : '' ?>>Monthly</option>
-                                        <option value="annually" <?= $topPeriod === 'annually' ? 'selected' : '' ?>>Annually</option>
-                                    </select>
-                                </div>
-                                <div class="control-group">
-                                    <label for="topSellingPicker" class="control-label" id="topSellingPickerLabel"><?= htmlspecialchars($topPickerLabel) ?></label>
-                                    <input
-                                        type="<?= htmlspecialchars($topPickerType) ?>"
-                                        name="top_value"
-                                        id="topSellingPicker"
-                                        class="period-input"
-                                        data-period-input
-                                        value="<?= htmlspecialchars($topPeriodValue) ?>"
-                                    >
-                                    <span class="control-hint" id="topSellingRangeHint"><?= htmlspecialchars($topRangeDisplay) ?></span>
-                                </div>
-                            </form>
-                        </div>
+                        <form
+                            method="get"
+                            action="dashboard.php"
+                            id="topSellingFilters"
+                            class="widget-controls period-form"
+                            data-period="<?= htmlspecialchars($topPeriod) ?>"
+                            data-value="<?= htmlspecialchars($topPeriodValue) ?>"
+                            data-range="<?= htmlspecialchars($topRangeDisplay) ?>"
+                        >
+                            <?php foreach ($_GET as $param => $value): ?>
+                                <?php if (!in_array($param, ['top_period', 'top_value', 'top_range'], true) && !is_array($value)): ?>
+                                    <input type="hidden" name="<?= htmlspecialchars($param) ?>" value="<?= htmlspecialchars($value) ?>">
+                                <?php endif; ?>
+                            <?php endforeach; ?>
+                            <div class="control-group">
+                                <label for="topSellingPeriod" class="control-label">View</label>
+                                <select name="top_period" id="topSellingPeriod" class="period-dropdown" data-period-select>
+                                    <option value="daily" <?= $topPeriod === 'daily' ? 'selected' : '' ?>>Daily</option>
+                                    <option value="weekly" <?= $topPeriod === 'weekly' ? 'selected' : '' ?>>Weekly</option>
+                                    <option value="monthly" <?= $topPeriod === 'monthly' ? 'selected' : '' ?>>Monthly</option>
+                                    <option value="annually" <?= $topPeriod === 'annually' ? 'selected' : '' ?>>Annually</option>
+                                </select>
+                            </div>
+                            <div class="control-group">
+                                <label for="topSellingPicker" class="control-label" id="topSellingPickerLabel"><?= htmlspecialchars($topPickerLabel) ?></label>
+                                <input
+                                    type="<?= htmlspecialchars($topPickerType) ?>"
+                                    name="top_value"
+                                    id="topSellingPicker"
+                                    class="period-input"
+                                    data-period-input
+                                    value="<?= htmlspecialchars($topPeriodValue) ?>"
+                                >
+                                <span class="control-hint" id="topSellingRangeHint"><?= htmlspecialchars($topRangeDisplay) ?></span>
+                            </div>
+                        </form>
                     </div>
                     <div class="widget-content">
-                        <div class="selected-period">Showing data for <strong><?= htmlspecialchars($topPeriodLabel) ?></strong></div>
+                        <div class="selected-period">Showing data for <strong id="topSellingSelectedLabel"><?= htmlspecialchars($topPeriodLabel) ?></strong></div>
                         <?php if (empty($top)): ?>
                         <div class="empty-state">
                             <i class="fas fa-chart-bar" style="font-size: 2rem; margin-bottom: 10px;"></i>

--- a/dgz_motorshop_system/assets/css/dashboard/dashboard.css
+++ b/dgz_motorshop_system/assets/css/dashboard/dashboard.css
@@ -256,39 +256,67 @@ body {
     gap: 12px;
 }
 
+
 .period-selector {
-    position: relative;
+    display: flex;
+    align-items: center;
 }
 
-#top_range {
-    appearance: none;
-    background: linear-gradient(135deg, #3498db, #2980b9);
-    color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 10px 40px 10px 16px;
-    font-size: 14px;
+.period-form {
+    display: flex;
+    align-items: flex-end;
+    gap: 16px;
+}
+
+.period-form .control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.control-label {
+    font-size: 12px;
     font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #7f8c8d;
+}
+
+.period-dropdown,
+.period-input {
+    border: 1px solid #dce3ea;
+    border-radius: 8px;
+    padding: 10px 14px;
+    font-size: 14px;
+    color: #2c3e50;
+    background: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.period-dropdown {
+    min-width: 130px;
+}
+
+.period-input {
+    min-width: 160px;
+}
+
+.period-dropdown:focus,
+.period-input:focus {
     outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.15);
 }
 
-#top_range:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(52, 152, 219, 0.3);
+.control-hint {
+    font-size: 12px;
+    color: #95a5a6;
 }
 
-.period-selector::after {
-    content: '\f078';
-    font-family: 'Font Awesome 6 Free';
-    font-weight: 900;
-    position: absolute;
-    right: 12px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: white;
-    pointer-events: none;
+.selected-period {
+    font-size: 13px;
+    color: #7f8c8d;
+    margin-bottom: 12px;
 }
 
 @media (max-width: 768px) {
@@ -298,7 +326,15 @@ body {
         align-items: flex-start;
     }
     
-    #top_range {
+    .period-form {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .period-dropdown,
+    .period-input {
         width: 100%;
     }
 }

--- a/dgz_motorshop_system/assets/css/dashboard/dashboard.css
+++ b/dgz_motorshop_system/assets/css/dashboard/dashboard.css
@@ -257,15 +257,11 @@ body {
 }
 
 
-.period-selector {
-    display: flex;
-    align-items: center;
-}
-
 .period-form {
     display: flex;
     align-items: flex-end;
     gap: 16px;
+    flex-wrap: wrap;
 }
 
 .period-form .control-group {
@@ -311,6 +307,7 @@ body {
 .control-hint {
     font-size: 12px;
     color: #95a5a6;
+    min-height: 16px;
 }
 
 .selected-period {

--- a/dgz_motorshop_system/assets/css/dashboard/dashboard.css
+++ b/dgz_motorshop_system/assets/css/dashboard/dashboard.css
@@ -239,13 +239,14 @@ body {
 }
 
 .widget-header {
-     height: 84px;              /* pick a value you like (56–68px works) */
-  padding: 0 25px;   
+    padding: 20px 24px;
     border-bottom: 1px solid #e9ecef;
     background: #f8f9fa;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: 16px;
+    flex-wrap: wrap;
 }
 .widget-title {
     font-size: 18px;
@@ -254,14 +255,17 @@ body {
     display: flex;
     align-items: center;
     gap: 12px;
+    margin: 0;
+    flex: 1 1 auto;
 }
 
 
 .period-form {
     display: flex;
-    align-items: flex-end;
-    gap: 16px;
+    align-items: flex-start;
+    gap: 12px;
     flex-wrap: wrap;
+    margin-left: auto;
 }
 
 .period-form .control-group {
@@ -312,22 +316,23 @@ body {
 
 .selected-period {
     font-size: 13px;
-    color: #7f8c8d;
-    margin-bottom: 12px;
+    color: #64748b;
+    margin: 0 0 16px 0;
 }
 
 @media (max-width: 768px) {
     .widget-header {
         flex-direction: column;
-        gap: 10px;
-        align-items: flex-start;
+        align-items: stretch;
+        gap: 12px;
     }
-    
+
     .period-form {
         width: 100%;
         flex-direction: column;
         align-items: stretch;
-        gap: 12px;
+        gap: 10px;
+        margin-left: 0;
     }
 
     .period-dropdown,

--- a/dgz_motorshop_system/assets/css/dashboard/dashboard.css
+++ b/dgz_motorshop_system/assets/css/dashboard/dashboard.css
@@ -197,15 +197,25 @@ body {
 }
 
 .stat-card {
+    display: block;
     background: white;
     padding: 25px;
     border-radius: 12px;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
     border-left: 4px solid #3498db;
     transition: transform 0.3s ease;
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
 }
 
 .stat-card:hover {
+    transform: translateY(-2px);
+}
+
+.stat-card:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.3);
     transform: translateY(-2px);
 }
 

--- a/dgz_motorshop_system/assets/js/dashboard/topSellingFilters.js
+++ b/dgz_motorshop_system/assets/js/dashboard/topSellingFilters.js
@@ -77,18 +77,61 @@
                 return;
             }
 
-            if (!description || !window.SalesPeriodFilters || typeof window.SalesPeriodFilters.formatRangeText !== 'function') {
+            if (!description) {
                 hintElement.textContent = initialHint || '';
                 return;
             }
 
-            const rangeText = window.SalesPeriodFilters.formatRangeText({
-                start: description.rangeStart,
-                end: description.rangeEnd,
-            });
-            const nextHint = rangeText || '';
+            const nextHint = formatRangeHint(description.rangeStart, description.rangeEnd);
             hintElement.textContent = nextHint;
             initialHint = nextHint;
+        }
+
+        function formatRangeHint(start, end) {
+            const startDate = parseYMD(start);
+            const endDate = parseYMD(end);
+
+            if (!startDate && !endDate) {
+                return initialHint || '';
+            }
+
+            const formattedStart = formatFriendlyDate(startDate);
+            const formattedEnd = formatFriendlyDate(endDate);
+
+            if (!formattedEnd || formattedStart === formattedEnd) {
+                return formattedStart || formattedEnd || '';
+            }
+
+            if (!formattedStart) {
+                return formattedEnd;
+            }
+
+            return `${formattedStart} - ${formattedEnd}`;
+        }
+
+        function parseYMD(value) {
+            if (!value) {
+                return null;
+            }
+
+            const parts = value.split('-').map((part) => parseInt(part, 10));
+            if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+                return null;
+            }
+
+            return new Date(parts[0], parts[1] - 1, parts[2]);
+        }
+
+        function formatFriendlyDate(date) {
+            if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+                return '';
+            }
+
+            return date.toLocaleDateString('en-US', {
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric',
+            });
         }
     }
 })(window, document);

--- a/dgz_motorshop_system/assets/js/dashboard/topSellingFilters.js
+++ b/dgz_motorshop_system/assets/js/dashboard/topSellingFilters.js
@@ -11,6 +11,7 @@
         const valueInput = document.getElementById('topSellingPicker');
         const labelElement = document.getElementById('topSellingPickerLabel');
         const hintElement = document.getElementById('topSellingRangeHint');
+        const selectedLabel = document.getElementById('topSellingSelectedLabel');
 
         if (!form || !periodSelect || !valueInput || !labelElement) {
             return;
@@ -18,7 +19,7 @@
 
         const initialPeriod = form.dataset.period || periodSelect.value || 'daily';
         const initialValue = form.dataset.value || valueInput.value || '';
-        const initialHint = form.dataset.range || '';
+        let initialHint = form.dataset.range || '';
 
         const filters = window.SalesPeriodFilters.create({
             periodSelect,
@@ -28,14 +29,66 @@
             onChange: (state) => {
                 periodSelect.value = state.period;
                 valueInput.value = state.value;
+                const description = safeDescribe(state.period, state.value);
+                updateSelectedLabel(description);
+                updateHint(description);
                 form.submit();
             },
         });
 
         filters.setPeriod(initialPeriod, initialValue);
 
-        if (hintElement) {
-            hintElement.textContent = initialHint;
+        const initialDescription = safeDescribe(initialPeriod, initialValue);
+        if (initialHint) {
+            updateHint(initialHint);
+        } else {
+            updateHint(initialDescription);
+        }
+
+        updateSelectedLabel(initialDescription);
+
+        function safeDescribe(period, value) {
+            if (!window.SalesPeriodFilters || typeof window.SalesPeriodFilters.describe !== 'function') {
+                return {};
+            }
+
+            try {
+                return window.SalesPeriodFilters.describe(period, value);
+            } catch (error) {
+                console.error('Failed to describe top selling period', error);
+                return {};
+            }
+        }
+
+        function updateSelectedLabel(description) {
+            if (selectedLabel && description && description.label) {
+                selectedLabel.textContent = description.label;
+            }
+        }
+
+        function updateHint(description) {
+            if (!hintElement) {
+                return;
+            }
+
+            if (typeof description === 'string') {
+                hintElement.textContent = description;
+                initialHint = description;
+                return;
+            }
+
+            if (!description || !window.SalesPeriodFilters || typeof window.SalesPeriodFilters.formatRangeText !== 'function') {
+                hintElement.textContent = initialHint || '';
+                return;
+            }
+
+            const rangeText = window.SalesPeriodFilters.formatRangeText({
+                start: description.rangeStart,
+                end: description.rangeEnd,
+            });
+            const nextHint = rangeText || '';
+            hintElement.textContent = nextHint;
+            initialHint = nextHint;
         }
     }
 })(window, document);

--- a/dgz_motorshop_system/assets/js/dashboard/topSellingFilters.js
+++ b/dgz_motorshop_system/assets/js/dashboard/topSellingFilters.js
@@ -1,0 +1,41 @@
+(function (window, document) {
+    document.addEventListener('DOMContentLoaded', initTopSellingFilters);
+
+    function initTopSellingFilters() {
+        if (!window.SalesPeriodFilters) {
+            return;
+        }
+
+        const form = document.getElementById('topSellingFilters');
+        const periodSelect = document.getElementById('topSellingPeriod');
+        const valueInput = document.getElementById('topSellingPicker');
+        const labelElement = document.getElementById('topSellingPickerLabel');
+        const hintElement = document.getElementById('topSellingRangeHint');
+
+        if (!form || !periodSelect || !valueInput || !labelElement) {
+            return;
+        }
+
+        const initialPeriod = form.dataset.period || periodSelect.value || 'daily';
+        const initialValue = form.dataset.value || valueInput.value || '';
+        const initialHint = form.dataset.range || '';
+
+        const filters = window.SalesPeriodFilters.create({
+            periodSelect,
+            valueInput,
+            labelElement,
+            hintElement,
+            onChange: (state) => {
+                periodSelect.value = state.period;
+                valueInput.value = state.value;
+                form.submit();
+            },
+        });
+
+        filters.setPeriod(initialPeriod, initialValue);
+
+        if (hintElement) {
+            hintElement.textContent = initialHint;
+        }
+    }
+})(window, document);


### PR DESCRIPTION
## Summary
- integrate the shared sales period resolver into the dashboard top-selling query
- add period/value controls and styling so the widget can target specific days, weeks, months, or years
- wire up a dashboard script that reuses the sales period helper to submit selections automatically

## Testing
- php -l dgz_motorshop_system/admin/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68e4854b6204832fb63c3e7b9e1878e0