### PR TITLE
Add decline attachment uploads and email support

### DIFF
--- a/dgz_motorshop_system/admin/includes/decline_reasons.php
+++ b/dgz_motorshop_system/admin/includes/decline_reasons.php
@@ -51,6 +51,15 @@ if (!function_exists('ensureOrderDeclineSchema')) {
             error_log('Unable to ensure orders.decline_reason_note column: ' . $e->getMessage());
         }
 
+        try {
+            $hasAttachmentPath = $pdo->query("SHOW COLUMNS FROM orders LIKE 'decline_attachment_path'");
+            if ($hasAttachmentPath === false || $hasAttachmentPath->fetch() === false) {
+                $pdo->exec("ALTER TABLE orders ADD COLUMN decline_attachment_path VARCHAR(255) NULL");
+            }
+        } catch (Throwable $e) {
+            error_log('Unable to ensure orders.decline_attachment_path column: ' . $e->getMessage());
+        }
+
         $ensured = true;
     }
 }

--- a/dgz_motorshop_system/admin/pos.php
+++ b/dgz_motorshop_system/admin/pos.php
@@ -1466,6 +1466,9 @@ if ($receiptDataJson === false) {
             <button type="button" id="openManageDeclineReasons" class="manage-reasons-button">Manage reasons</button>
             <label for="declineReasonNote" class="decline-label">Additional Details (optional)</label>
             <textarea id="declineReasonNote" rows="3" placeholder="Add context that will appear in the email."></textarea>
+            <!-- Added: optional evidence upload that is attached to the outgoing email -->
+            <label for="declineAttachment" class="decline-label">Attach proof (optional)</label>
+            <input type="file" id="declineAttachment" accept="image/*,application/pdf">
             <div id="declineModalError" class="decline-modal-error" aria-live="polite"></div>
             <div class="decline-modal-actions">
                 <button type="button" id="cancelDeclineOrder" class="secondary-button">Cancel</button>

--- a/dgz_motorshop_system/includes/email.php
+++ b/dgz_motorshop_system/includes/email.php
@@ -3,28 +3,29 @@
 require_once __DIR__ . '/../config/mailer.php';
 
 /**
- * Send an email with optional PDF attachment
- * 
+ * Send an email with optional PDF and file attachments.
+ *
  * @param string $to Recipient email address
  * @param string $subject Email subject
  * @param string $body Email body content (HTML)
  * @param string|null $pdfContent Optional PDF content to attach
  * @param string $pdfFilename Optional filename for the PDF attachment (default: 'document.pdf')
+ * @param array<int, string|array{path:string,name?:string}> $fileAttachments Optional list of file attachments
  * @return bool True if email was sent successfully, false otherwise
  */
 if (!function_exists('sendEmail')) {
-function sendEmail(string $to, string $subject, string $body, ?string $pdfContent = null, string $pdfFilename = 'document.pdf'): bool
+function sendEmail(string $to, string $subject, string $body, ?string $pdfContent = null, string $pdfFilename = 'document.pdf', array $fileAttachments = []): bool
 {
     error_log("Starting email send process to: $to");
     error_log("Subject: $subject");
-    
+
     try {
         $mail = getMailer();
-        
+
         // Clear any previous recipients
         $mail->clearAddresses();
         $mail->clearAttachments();
-        
+
         // Add recipient with validation
         if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
             throw new Exception("Invalid email address: $to");
@@ -35,7 +36,7 @@ function sendEmail(string $to, string $subject, string $body, ?string $pdfConten
         $mail->isHTML(true);
         $mail->Subject = $subject;
         $mail->Body    = $body;
-        
+
         // Add plain text version for better deliverability
         $mail->AltBody = strip_tags(str_replace(['<br>', '<br/>', '<br />'], "\n", $body));
 
@@ -50,24 +51,49 @@ function sendEmail(string $to, string $subject, string $body, ?string $pdfConten
                 throw $e; // Re-throw to be caught by outer try-catch
             }
         }
-        
+
+        // Added: attach any uploaded files (e.g., disapproval evidence).
+        foreach ($fileAttachments as $attachment) {
+            $path = '';
+            $name = '';
+            if (is_string($attachment)) {
+                $path = $attachment;
+                $name = basename($attachment);
+            } elseif (is_array($attachment) && isset($attachment['path'])) {
+                $path = (string) $attachment['path'];
+                $name = isset($attachment['name']) ? (string) $attachment['name'] : basename($path);
+            }
+
+            if ($path === '' || !is_file($path)) {
+                continue;
+            }
+
+            try {
+                $mail->addAttachment($path, $name);
+                error_log('File attachment added: ' . $path);
+            } catch (Exception $e) {
+                error_log('Failed to attach file: ' . $e->getMessage());
+                throw $e;
+            }
+        }
+
         // Additional headers for better deliverability
         $mail->addCustomHeader('X-Mailer', 'DGZ Motorshop System');
         $mail->addCustomHeader('X-Priority', '3');
         $mail->addCustomHeader('X-MSMail-Priority', 'Normal');
         $mail->addCustomHeader('Importance', 'Normal');
-        
+
         // Set encoding
         $mail->CharSet = 'UTF-8';
         $mail->Encoding = 'base64';
 
         $result = $mail->send();
         error_log("Email send result: " . ($result ? 'SUCCESS' : 'FAILED'));
-        
+
         // Clear addresses for next use
         $mail->clearAddresses();
         $mail->clearAttachments();
-        
+
         return $result;
     } catch (Exception $e) {
         error_log("Message could not be sent. Mailer Error: {$mail->ErrorInfo}");


### PR DESCRIPTION
## Summary
- add an optional attachment field to the POS disapproval modal and update the client flow to submit files
- persist decline attachments on the server, update schema helpers, and attach uploaded files to disapproval emails
- extend the shared mail helper to handle arbitrary file attachments while keeping PDF support

## Testing
- php -l dgz_motorshop_system/admin/orderDisapprove.php
- php -l dgz_motorshop_system/admin/includes/decline_reasons.php
- php -l dgz_motorshop_system/includes/email.php


------
https://chatgpt.com/codex/tasks/task_e_68e4e384a9c4832f8a8e0c4bcb5c421a