### PR TITLE
Add user deactivation support and enforce inactive user restrictions

### DIFF
--- a/dgz_motorshop_system/admin/dashboard.php
+++ b/dgz_motorshop_system/admin/dashboard.php
@@ -25,11 +25,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 // Fetch the authenticated user's information for the profile modal
 $current_user = null;
 try {
-    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $current_user = $stmt->fetch();
 } catch (Exception $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$current_user) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 // Simple stats

--- a/dgz_motorshop_system/admin/inventory.php
+++ b/dgz_motorshop_system/admin/inventory.php
@@ -31,11 +31,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 // Fetch the authenticated user's information for the profile modal
 $current_user = null;
 try {
-    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $current_user = $stmt->fetch();
 } catch (Exception $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$current_user) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 // Cache the current user's name for activity logs that survive account removal.

--- a/dgz_motorshop_system/admin/partials/user_management_section.php
+++ b/dgz_motorshop_system/admin/partials/user_management_section.php
@@ -84,7 +84,7 @@ $showUserManagementBackButton = $showUserManagementBackButton ?? true;
                     </thead>
                     <tbody>
                         <?php foreach ($userManagementUsers as $user): ?>
-                            <tr>
+                        <tr class="<?php echo !empty($user['deleted_at']) ? 'user-row-inactive' : ''; ?>">
                                 <td><?php echo (int) $user['id']; ?></td>
                                 <td><?php echo htmlspecialchars($user['name']); ?></td>
                                 <td><?php echo htmlspecialchars($user['email'] ?? '—'); ?></td>
@@ -96,14 +96,19 @@ $showUserManagementBackButton = $showUserManagementBackButton ?? true;
                                 </td>
                                 <td><?php echo date('M d, Y H:i', strtotime($user['created_at'])); ?></td>
                                 <td class="table-actions">
-                                    <?php if ($user['role'] === 'staff'): ?>
-                                        <form method="post" class="inline-form" onsubmit="return confirm('Remove this staff account? This action cannot be undone.');">
+                                    <?php $isDeactivated = !empty($user['deleted_at']); ?>
+                                    <?php if ($user['role'] === 'staff' && !$isDeactivated): ?>
+                                        <form method="post" class="inline-form" onsubmit="return confirm('Deactivate this staff account? They will no longer be able to sign in.');">
                                             <input type="hidden" name="delete_user" value="1">
                                             <input type="hidden" name="delete_user_id" value="<?php echo (int) $user['id']; ?>">
                                             <button type="submit" class="danger-action">
-                                                <i class="fas fa-user-minus"></i> Remove
+                                                <i class="fas fa-user-slash"></i> Deactivate
                                             </button>
                                         </form>
+                                    <?php elseif ($user['role'] === 'staff' && $isDeactivated): ?>
+                                        <span class="status-badge status-inactive">
+                                            <i class="fas fa-user-slash"></i> Deactivated
+                                        </span>
                                     <?php else: ?>
                                         <span class="muted">—</span>
                                     <?php endif; ?>

--- a/dgz_motorshop_system/admin/pos.php
+++ b/dgz_motorshop_system/admin/pos.php
@@ -126,11 +126,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 // Fetch the authenticated user's information for the profile modal
 $current_user = null;
 try {
-    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $current_user = $stmt->fetch();
 } catch (Exception $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$current_user) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 function format_profile_date(?string $datetime): string

--- a/dgz_motorshop_system/admin/products.php
+++ b/dgz_motorshop_system/admin/products.php
@@ -163,11 +163,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 // Fetch the authenticated user's information for the profile modal
 $current_user = null;
 try {
-    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $current_user = $stmt->fetch();
 } catch (Exception $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$current_user) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 function format_profile_date(?string $datetime): string

--- a/dgz_motorshop_system/admin/sales.php
+++ b/dgz_motorshop_system/admin/sales.php
@@ -110,11 +110,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 // Fetch the authenticated user's information for the profile modal
 $current_user = null;
 try {
-    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $current_user = $stmt->fetch();
 } catch (Exception $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$current_user) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 function format_profile_date(?string $datetime): string

--- a/dgz_motorshop_system/admin/stockReceiptView.php
+++ b/dgz_motorshop_system/admin/stockReceiptView.php
@@ -19,11 +19,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 
 $currentUser = null;
 try {
-    $stmt = $pdo->prepare('SELECT id, name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT id, name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $currentUser = $stmt->fetch(PDO::FETCH_ASSOC);
 } catch (Throwable $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$currentUser) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 $receiptId = isset($_GET['receipt']) ? (int)$_GET['receipt'] : 0;

--- a/dgz_motorshop_system/admin/stockRequests.php
+++ b/dgz_motorshop_system/admin/stockRequests.php
@@ -19,11 +19,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 // Fetch the authenticated user's information for the profile modal
 $current_user = null;
 try {
-    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $current_user = $stmt->fetch();
 } catch (Exception $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$current_user) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 // Cache the current user's name for audit history rows that remain after deletion.

--- a/dgz_motorshop_system/admin/userManagement.php
+++ b/dgz_motorshop_system/admin/userManagement.php
@@ -24,11 +24,15 @@ $inventoryNotificationCount = $inventoryNotificationData['active_count'];
 // Fetch the authenticated user's information for the profile modal
 $current_user = null;
 try {
-    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT name, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL');
     $stmt->execute([$_SESSION['user_id']]);
     $current_user = $stmt->fetch();
 } catch (Exception $e) {
     error_log('User lookup failed: ' . $e->getMessage());
+}
+
+if (!$current_user) {
+    logoutDeactivatedUser('Your account is no longer active.');
 }
 
 function format_profile_date(?string $datetime): string

--- a/dgz_motorshop_system/assets/css/users/userManagement.css
+++ b/dgz_motorshop_system/assets/css/users/userManagement.css
@@ -192,6 +192,27 @@ html, body {
     color: #047857;
 }
 
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.status-inactive {
+    background-color: rgba(239, 68, 68, 0.15);
+    color: #b91c1c;
+}
+
+.user-row-inactive td {
+    color: #9ca3af;
+}
+
 .empty-row {
     text-align: center;
     color: #6b7280;

--- a/dgz_motorshop_system/config/config.php
+++ b/dgz_motorshop_system/config/config.php
@@ -167,3 +167,21 @@ if (!function_exists('enforceStaffAccess')) {
         }
     }
 }
+
+if (!function_exists('logoutDeactivatedUser')) {
+    function logoutDeactivatedUser(string $message = 'Your account has been deactivated.'): void
+    {
+        $query = http_build_query([
+            'status' => 'error',
+            'msg'    => $message,
+        ]);
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION = [];
+            session_destroy();
+        }
+
+        header('Location: login.php?' . $query);
+        exit;
+    }
+}

--- a/dgz_motorshop_system/init.sql
+++ b/dgz_motorshop_system/init.sql
@@ -10,7 +10,8 @@ CREATE TABLE IF NOT EXISTS users (
   email VARCHAR(100) UNIQUE,
   password VARCHAR(255),
   role ENUM('admin','staff') DEFAULT 'staff',
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TIMESTAMP NULL DEFAULT NULL
 );
 
 -- products table


### PR DESCRIPTION
## Summary
- add a nullable `deleted_at` column to the `users` table and introduce a helper to cleanly log out deactivated accounts
- replace hard deletes in the user management module with soft deactivation and show inactive staff directly in the UI
- ensure admin authentication, profile loaders, and password recovery flows ignore deactivated users and log them out when necessary

## Testing
- php -l dgz_motorshop_system/admin/login.php dgz_motorshop_system/admin/includes/user_management_data.php dgz_motorshop_system/admin/partials/user_management_section.php dgz_motorshop_system/admin/dashboard.php dgz_motorshop_system/admin/userManagement.php dgz_motorshop_system/admin/stockRequests.php dgz_motorshop_system/admin/sales.php dgz_motorshop_system/admin/stockEntry.php dgz_motorshop_system/admin/stockReceiptView.php dgz_motorshop_system/admin/products.php dgz_motorshop_system/admin/inventory.php dgz_motorshop_system/admin/pos.php dgz_motorshop_system/admin/settings.php dgz_motorshop_system/admin/forgot_password.php dgz_motorshop_system/admin/reset_password.php dgz_motorshop_system/config/config.php

------
https://chatgpt.com/codex/tasks/task_e_68e54338977c832fb974a6896f022493