### PR TITLE
Add customer note support on checkout and POS

### DIFF
--- a/dgz_motorshop_system/admin/get_transaction_details.php
+++ b/dgz_motorshop_system/admin/get_transaction_details.php
@@ -45,6 +45,9 @@ try {
 
     $order['reference_number'] = $details['reference'];
     $order['phone'] = $order['phone'] ?? null;
+    $order['customer_note'] = isset($order['customer_note']) && $order['customer_note'] !== null
+        ? (string) $order['customer_note']
+        : (isset($order['notes']) ? (string) $order['notes'] : ''); // Added normalized field for cashier notes
 
     echo json_encode([
         'order' => $order,

--- a/dgz_motorshop_system/admin/pos.php
+++ b/dgz_motorshop_system/admin/pos.php
@@ -1487,15 +1487,15 @@ if ($receiptDataJson === false) {
                             <label>Phone:</label>
                             <span id="onlineOrderPhone"></span>
                         </div>
-                        <div class="info-item note-item" id="onlineOrderNoteContainer" style="display:none;">
-                            <!-- Added container to show the cashier note captured during checkout -->
-                            <label>Customer Note:</label>
-                            <span id="onlineOrderNote"></span>
-                        </div>
                         <div class="info-item" id="onlineOrderReferenceWrapper" style="display:none;">
                             <label>Reference:</label>
                             <span id="onlineOrderReference"></span>
                         </div>
+                    </div>
+                    <div class="info-item note-item" id="onlineOrderNoteContainer" style="display:none;">
+                        <!-- Updated container so the cashier note sits at the end of the transaction details -->
+                        <label>Customer Note:</label>
+                        <span id="onlineOrderNote"></span>
                     </div>
                 </div>
                 <div class="order-items">

--- a/dgz_motorshop_system/assets/css/pos/pos.css
+++ b/dgz_motorshop_system/assets/css/pos/pos.css
@@ -1194,6 +1194,12 @@ body {
     font-weight: 600;
     word-break: break-word;
 }
+.modal-overlay .transaction-modal .info-item.note-item {
+    grid-column: 1 / -1; /* Added so the cashier note stretches across the modal */
+}
+.modal-overlay .transaction-modal .info-item.note-item span {
+    white-space: pre-wrap; /* Added to keep multi-line notes readable */
+}
 
 .modal-overlay .transaction-modal .order-items {
     margin-top: 24px;

--- a/dgz_motorshop_system/assets/css/pos/pos.css
+++ b/dgz_motorshop_system/assets/css/pos/pos.css
@@ -1196,9 +1196,23 @@ body {
 }
 .modal-overlay .transaction-modal .info-item.note-item {
     grid-column: 1 / -1; /* Added so the cashier note stretches across the modal */
+    padding: 16px;
+    border-radius: 12px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    margin-top: 12px;
+}
+.modal-overlay .transaction-modal .info-item.note-item label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: #0f172a;
+    text-transform: uppercase;
 }
 .modal-overlay .transaction-modal .info-item.note-item span {
     white-space: pre-wrap; /* Added to keep multi-line notes readable */
+    color: #0f172a;
+    font-weight: 600;
 }
 
 .modal-overlay .transaction-modal .order-items {

--- a/dgz_motorshop_system/assets/js/pos/posMain.js
+++ b/dgz_motorshop_system/assets/js/pos/posMain.js
@@ -60,6 +60,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const onlineOrderPayment = document.getElementById('onlineOrderPayment');
             const onlineOrderEmail = document.getElementById('onlineOrderEmail');
             const onlineOrderPhone = document.getElementById('onlineOrderPhone');
+            const onlineOrderNoteContainer = document.getElementById('onlineOrderNoteContainer');
+            const onlineOrderNote = document.getElementById('onlineOrderNote');
             const onlineOrderReferenceWrapper = document.getElementById('onlineOrderReferenceWrapper');
             const onlineOrderReference = document.getElementById('onlineOrderReference');
             const onlineOrderItemsBody = document.getElementById('onlineOrderItemsBody');
@@ -155,6 +157,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 onlineOrderPayment.textContent = safePayment !== '' ? safePayment : 'N/A';
                 onlineOrderEmail.textContent = (order.email || '').toString();
                 onlineOrderPhone.textContent = (order.phone || '').toString();
+
+                if (onlineOrderNoteContainer && onlineOrderNote) {
+                    const noteText = ((order.customer_note ?? order.notes) || '').toString().trim();
+                    if (noteText !== '') {
+                        onlineOrderNote.textContent = noteText; // Added cashier note so staff can review special instructions
+                        onlineOrderNoteContainer.style.display = 'flex';
+                    } else {
+                        onlineOrderNote.textContent = '';
+                        onlineOrderNoteContainer.style.display = 'none';
+                    }
+                }
 
                 if (referenceNumber && safePayment.toLowerCase() === 'gcash') {
                     onlineOrderReferenceWrapper.style.display = 'flex';

--- a/dgz_motorshop_system/ordering/checkout.php
+++ b/dgz_motorshop_system/ordering/checkout.php
@@ -1,7 +1,6 @@
 <?php
 require __DIR__ . '/../config/config.php';
 $pdo = db();
-ensureOrdersCustomerNoteColumn($pdo); // Added call to prepare storage for customer cashier notes
 $errors = [];
 $referenceInput = '';
 
@@ -16,7 +15,7 @@ if (!function_exists('ordersHasReferenceColumn')) {
         try {
             $stmt = $pdo->query("SHOW COLUMNS FROM orders LIKE 'reference_no'");
             $hasColumn = $stmt !== false && $stmt->fetch() !== false;
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $hasColumn = false;
         }
 
@@ -36,7 +35,7 @@ if (!function_exists('ordersHasColumn')) {
             $stmt = $pdo->prepare("SHOW COLUMNS FROM orders LIKE ?");
             $stmt->execute([$column]);
             $cache[$column] = $stmt !== false && $stmt->fetch() !== false;
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $cache[$column] = false;
         }
         return $cache[$column];
@@ -64,11 +63,13 @@ if (!function_exists('ensureOrdersCustomerNoteColumn')) {
             }
 
             $pdo->exec("ALTER TABLE orders ADD COLUMN customer_note TEXT NULL");
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             error_log('Unable to add customer_note column: ' . $e->getMessage());
         }
     }
 }
+
+ensureOrdersCustomerNoteColumn($pdo); // Added call to prepare storage for customer cashier notes
 
 if (!function_exists('normaliseCartItems')) {
     function normaliseCartItems($items): array
@@ -294,11 +295,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
         $values  = [$customer_name, $address, $total, $payment_method, $proof_path];
 
         // Write to new columns when present
-        try { $hasEmailColumn = ordersHasColumn($pdo, 'email'); } catch (Throwable $e) { $hasEmailColumn = false; }
-        try { $hasPhoneColumn = ordersHasColumn($pdo, 'phone'); } catch (Throwable $e) { $hasPhoneColumn = false; }
-        try { $hasLegacyContact = ordersHasColumn($pdo, 'contact'); } catch (Throwable $e) { $hasLegacyContact = false; }
-        try { $hasCustomerNoteColumn = ordersHasColumn($pdo, 'customer_note'); } catch (Throwable $e) { $hasCustomerNoteColumn = false; } // Added detection for dedicated notes column
-        try { $hasLegacyNotesColumn = ordersHasColumn($pdo, 'notes'); } catch (Throwable $e) { $hasLegacyNotesColumn = false; } // Added fallback for legacy installs using generic notes
+        try { $hasEmailColumn = ordersHasColumn($pdo, 'email'); } catch (Exception $e) { $hasEmailColumn = false; }
+        try { $hasPhoneColumn = ordersHasColumn($pdo, 'phone'); } catch (Exception $e) { $hasPhoneColumn = false; }
+        try { $hasLegacyContact = ordersHasColumn($pdo, 'contact'); } catch (Exception $e) { $hasLegacyContact = false; }
+        try { $hasCustomerNoteColumn = ordersHasColumn($pdo, 'customer_note'); } catch (Exception $e) { $hasCustomerNoteColumn = false; } // Added detection for dedicated notes column
+        try { $hasLegacyNotesColumn = ordersHasColumn($pdo, 'notes'); } catch (Exception $e) { $hasLegacyNotesColumn = false; } // Added fallback for legacy installs using generic notes
 
         if ($hasEmailColumn) { $columns[] = 'email'; $values[] = $email; }
         if ($hasPhoneColumn) { $columns[] = 'phone'; $values[] = $phone; }

--- a/dgz_motorshop_system/ordering/checkout.php
+++ b/dgz_motorshop_system/ordering/checkout.php
@@ -1,6 +1,7 @@
 <?php
 require __DIR__ . '/../config/config.php';
 $pdo = db();
+ensureOrdersCustomerNoteColumn($pdo); // Added call to prepare storage for customer cashier notes
 $errors = [];
 $referenceInput = '';
 
@@ -39,6 +40,33 @@ if (!function_exists('ordersHasColumn')) {
             $cache[$column] = false;
         }
         return $cache[$column];
+    }
+}
+
+if (!function_exists('ensureOrdersCustomerNoteColumn')) {
+    /**
+     * Added helper to make sure the orders table can store cashier notes when the schema allows it.
+     */
+    function ensureOrdersCustomerNoteColumn(PDO $pdo): void
+    {
+        static $ensured = false;
+        if ($ensured) {
+            return;
+        }
+
+        $ensured = true;
+
+        try {
+            $stmt = $pdo->query("SHOW COLUMNS FROM orders LIKE 'customer_note'");
+            $hasCustomerNote = $stmt !== false && $stmt->fetch() !== false;
+            if ($hasCustomerNote) {
+                return;
+            }
+
+            $pdo->exec("ALTER TABLE orders ADD COLUMN customer_note TEXT NULL");
+        } catch (Throwable $e) {
+            error_log('Unable to add customer_note column: ' . $e->getMessage());
+        }
     }
 }
 
@@ -150,6 +178,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
     $email = trim($_POST['email'] ?? '');
     $phone = trim($_POST['phone'] ?? '');
     $address = trim($_POST['address']);
+    $customerNote = trim((string) ($_POST['customer_note'] ?? '')); // Added capture for optional cashier note
+    if (mb_strlen($customerNote) > 500) {
+        $customerNote = mb_substr($customerNote, 0, 500); // Added guard to keep notes reasonably short
+    }
     $payment_method = $_POST['payment_method'] ?? '';
     $referenceInput = trim($_POST['reference_number'] ?? '');
     $proof_path = null;
@@ -265,12 +297,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_name'])) {
         try { $hasEmailColumn = ordersHasColumn($pdo, 'email'); } catch (Throwable $e) { $hasEmailColumn = false; }
         try { $hasPhoneColumn = ordersHasColumn($pdo, 'phone'); } catch (Throwable $e) { $hasPhoneColumn = false; }
         try { $hasLegacyContact = ordersHasColumn($pdo, 'contact'); } catch (Throwable $e) { $hasLegacyContact = false; }
+        try { $hasCustomerNoteColumn = ordersHasColumn($pdo, 'customer_note'); } catch (Throwable $e) { $hasCustomerNoteColumn = false; } // Added detection for dedicated notes column
+        try { $hasLegacyNotesColumn = ordersHasColumn($pdo, 'notes'); } catch (Throwable $e) { $hasLegacyNotesColumn = false; } // Added fallback for legacy installs using generic notes
 
         if ($hasEmailColumn) { $columns[] = 'email'; $values[] = $email; }
         if ($hasPhoneColumn) { $columns[] = 'phone'; $values[] = $phone; }
         if ($hasLegacyContact) { $columns[] = 'contact'; $values[] = $email; }
 
         if ($hasReferenceColumn) { $columns[] = 'reference_no'; $values[] = $referenceNumber; }
+        if ($hasCustomerNoteColumn) { $columns[] = 'customer_note'; $values[] = $customerNote !== '' ? $customerNote : null; } // Added storage for cashier notes when column exists
+        elseif ($hasLegacyNotesColumn) { $columns[] = 'notes'; $values[] = $customerNote !== '' ? $customerNote : null; } // Added fallback storage for systems that already expose a generic notes column
 
         $columns[] = 'status';
         $values[]  = 'pending';
@@ -402,6 +438,11 @@ if (isset($_GET['success']) && $_GET['success'] === '1') {
                             <label>City</label>
                             <input type="text" name="city" value="<?= htmlspecialchars($_POST['city'] ?? '') ?>">
                         </div>
+                    </div>
+                    <div class="form-group">
+                        <!-- Added note textarea so customers can leave instructions for the cashier -->
+                        <label for="customer_note">Notes for the cashier</label>
+                        <textarea name="customer_note" id="customer_note" maxlength="500" placeholder="Add delivery instructions, preferred pickup time, etc."><?= htmlspecialchars($_POST['customer_note'] ?? '') ?></textarea>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add a customer note textarea to checkout and persist it when the orders table supports the column
- surface the saved note in the POS transaction details modal with layout updates
- normalize the note in the transaction details endpoint so the UI can reliably access it

## Testing
- php -l dgz_motorshop_system/ordering/checkout.php
- php -l dgz_motorshop_system/admin/pos.php
- php -l dgz_motorshop_system/admin/get_transaction_details.php

------
https://chatgpt.com/codex/tasks/task_e_68e556ee5d00832f861034153806abbb