### PR TITLE
Make POS transaction items table scrollable

### DIFF
--- a/dgz_motorshop_system/admin/get_transaction_details.php
+++ b/dgz_motorshop_system/admin/get_transaction_details.php
@@ -45,6 +45,9 @@ try {
 
     $order['reference_number'] = $details['reference'];
     $order['phone'] = $order['phone'] ?? null;
+    $order['customer_note'] = isset($order['customer_note']) && $order['customer_note'] !== null
+        ? (string) $order['customer_note']
+        : (isset($order['notes']) ? (string) $order['notes'] : ''); // Added normalized field for cashier notes
 
     echo json_encode([
         'order' => $order,

--- a/dgz_motorshop_system/assets/css/pos/pos.css
+++ b/dgz_motorshop_system/assets/css/pos/pos.css
@@ -1194,6 +1194,26 @@ body {
     font-weight: 600;
     word-break: break-word;
 }
+.modal-overlay .transaction-modal .info-item.note-item {
+    grid-column: 1 / -1; /* Added so the cashier note stretches across the modal */
+    padding: 16px;
+    border-radius: 12px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    margin-top: 12px;
+}
+.modal-overlay .transaction-modal .info-item.note-item label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: #0f172a;
+    text-transform: uppercase;
+}
+.modal-overlay .transaction-modal .info-item.note-item span {
+    white-space: pre-wrap; /* Added to keep multi-line notes readable */
+    color: #0f172a;
+    font-weight: 600;
+}
 
 .modal-overlay .transaction-modal .order-items {
     margin-top: 24px;
@@ -1204,6 +1224,9 @@ body {
     border-radius: 10px;
     overflow-x: auto;
     background: #fff;
+    /* Transaction detail items list - tweak max-height/overflow to adjust scroll behavior */
+    max-height: 320px;
+    overflow-y: auto;
 }
 
 .modal-overlay .transaction-modal .items-table {

--- a/dgz_motorshop_system/assets/js/pos/posMain.js
+++ b/dgz_motorshop_system/assets/js/pos/posMain.js
@@ -60,6 +60,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const onlineOrderPayment = document.getElementById('onlineOrderPayment');
             const onlineOrderEmail = document.getElementById('onlineOrderEmail');
             const onlineOrderPhone = document.getElementById('onlineOrderPhone');
+            const onlineOrderNoteContainer = document.getElementById('onlineOrderNoteContainer');
+            const onlineOrderNote = document.getElementById('onlineOrderNote');
             const onlineOrderReferenceWrapper = document.getElementById('onlineOrderReferenceWrapper');
             const onlineOrderReference = document.getElementById('onlineOrderReference');
             const onlineOrderItemsBody = document.getElementById('onlineOrderItemsBody');
@@ -155,6 +157,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 onlineOrderPayment.textContent = safePayment !== '' ? safePayment : 'N/A';
                 onlineOrderEmail.textContent = (order.email || '').toString();
                 onlineOrderPhone.textContent = (order.phone || '').toString();
+
+                if (onlineOrderNoteContainer && onlineOrderNote) {
+                    const noteText = ((order.customer_note ?? order.notes) || '').toString().trim();
+                    if (noteText !== '') {
+                        onlineOrderNote.textContent = noteText; // Added cashier note so staff can review special instructions
+                        onlineOrderNoteContainer.style.display = 'flex';
+                    } else {
+                        onlineOrderNote.textContent = '';
+                        onlineOrderNoteContainer.style.display = 'none';
+                    }
+                }
 
                 if (referenceNumber && safePayment.toLowerCase() === 'gcash') {
                     onlineOrderReferenceWrapper.style.display = 'flex';


### PR DESCRIPTION
## Summary
- move the cashier note container outside the order info grid so it appears last in the transaction details modal
- restyle the note block with a dedicated card treatment to highlight customer instructions for staff
- add a max-height to the transaction items list so large orders scroll inside the modal

## Testing
- php -l dgz_motorshop_system/admin/pos.php

------
https://chatgpt.com/codex/tasks/task_e_68e556ee5d00832f861034153806abbb