### PR TITLE
Ensure staff settings mirror admin layout and show profile details

### DIFF
--- a/dgz_motorshop_system/admin/login.php
+++ b/dgz_motorshop_system/admin/login.php
@@ -12,6 +12,30 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
         if (password_verify($pass, (string) $u['password'])) {
             $_SESSION['user_id']=$u['id'];
             $_SESSION['role']=$u['role'];
+
+            // Persist commonly used profile information for faster access in
+            // areas where the full database record is not required.
+            $resolvedName = null;
+            if (!empty($u['name'])) {
+                $resolvedName = $u['name'];
+            } elseif (!empty($u['full_name'])) {
+                $resolvedName = $u['full_name'];
+            } elseif (!empty($u['first_name']) || !empty($u['last_name'])) {
+                $first = trim((string) ($u['first_name'] ?? ''));
+                $last = trim((string) ($u['last_name'] ?? ''));
+                $resolvedName = trim($first . ' ' . $last);
+            }
+
+            if (!empty($resolvedName)) {
+                $_SESSION['user_name'] = $resolvedName;
+            }
+
+            if (!empty($u['created_at'])) {
+                $_SESSION['user_created_at'] = $u['created_at'];
+            } elseif (!empty($u['date_created'])) {
+                $_SESSION['user_created_at'] = $u['date_created'];
+            }
+
             header('Location: dashboard.php'); exit;
         }
     }

--- a/dgz_motorshop_system/assets/css/dashboard/dashboard.css
+++ b/dgz_motorshop_system/assets/css/dashboard/dashboard.css
@@ -602,6 +602,16 @@ body.modal-open {
     margin-bottom: 16px;
 }
 
+.settings-panel .access-restricted {
+    padding: 16px;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    border-radius: 12px;
+    color: #1d4ed8;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
 .settings-profile-details .profile-info {
     margin-top: 0;
 }

--- a/dgz_motorshop_system/config/config.php
+++ b/dgz_motorshop_system/config/config.php
@@ -142,6 +142,7 @@ if (!function_exists('staffAllowedAdminPages')) {
             'inventory.php',
             'sales_report_pdf.php',
             'stockEntry.php',
+            'settings.php',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- derive profile details from the full user record with multiple fallbacks so staff no longer see N/A values
- remember profile metadata in the session at login for consistent display across admin pages
- keep the user management section in the settings layout for staff with a clear restriction message and matching styling

## Testing
- php -l dgz_motorshop_system/admin/settings.php
- php -l dgz_motorshop_system/admin/login.php

------
https://chatgpt.com/codex/tasks/task_e_68e5625f1e9c832fbf17efefe1b2953a