### PR TITLE
Improve stock-in entry layout and PDF formatting

### DIFF
--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -314,78 +314,74 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                     <fieldset class="form-section line-items-section" aria-labelledby="lineItemsTitle" <?= $formLocked ? 'disabled' : '' ?>>
                         <legend id="lineItemsTitle">Line Items</legend>
                         <p class="table-hint table-hint-inline">Tip: Use Qty Expected to highlight discrepancies before posting.</p>
-                        <div class="table-wrapper">
-                            <table class="line-items-table">
-                                <thead>
-                                    <tr>
-                                        <th>Product <span class="required">*</span></th>
-                                        <th>Qty Expected</th>
-                                        <th>Qty Received <span class="required">*</span></th>
-                                        <th>Unit Cost</th>
-                                        <th>Expiry</th>
-                                        <th>Lot / Batch</th>
-                                        <th></th>
-                                    </tr>
-                                </thead>
-                                <tbody id="lineItemsBody">
-                                    <?php foreach ($existingItems as $index => $item): ?>
-                                        <?php
-                                            $productId = $item['product_id'];
-                                            $qtyExpected = $item['qty_expected'];
-                                            $qtyReceived = $item['qty_received'];
-                                            $unitCost = $item['unit_cost'];
-                                            $expiryDate = $item['expiry_date'];
-                                            $lotNumber = $item['lot_number'];
-                                            $rowHasDiscrepancy = !empty($item['has_discrepancy']);
-                                            $rowInvalidExpiry = !empty($item['invalid_expiry']);
-                                        ?>
-                                        <tr class="line-item-row<?= $rowHasDiscrepancy ? ' has-discrepancy' : '' ?>" data-selected-product="<?= $productId ? (int)$productId : '' ?>">
-                                            <td>
-                                                <div class="product-selector">
-                                                    <div class="product-search-wrapper">
-                                                        <input type="text" class="product-search" placeholder="Search name or code" value="">
-                                                        <button type="button" class="product-clear" aria-label="Clear selected product" hidden>
-                                                            <i class="fas fa-times"></i>
-                                                        </button>
-                                                        <div class="product-suggestions"></div>
-                                                    </div>
-                                                    <select name="product_id[]" class="product-select" required>
-                                                        <option value="">Select product</option>
-                                                        <?php foreach ($products as $product): ?>
-                                                            <option value="<?= (int)$product['id'] ?>" <?= $productId == (int)$product['id'] ? 'selected' : '' ?>>
-                                                                <?= htmlspecialchars($product['name']) ?>
-                                                            </option>
-                                                        <?php endforeach; ?>
-                                                    </select>
+                        <div id="lineItemsBody" class="line-items-body">
+                            <?php foreach ($existingItems as $index => $item): ?>
+                                <?php
+                                    $productId = $item['product_id'];
+                                    $qtyExpected = $item['qty_expected'];
+                                    $qtyReceived = $item['qty_received'];
+                                    $unitCost = $item['unit_cost'];
+                                    $expiryDate = $item['expiry_date'];
+                                    $lotNumber = $item['lot_number'];
+                                    $rowHasDiscrepancy = !empty($item['has_discrepancy']);
+                                    $rowInvalidExpiry = !empty($item['invalid_expiry']);
+                                ?>
+                                <div class="line-item-row<?= $rowHasDiscrepancy ? ' has-discrepancy' : '' ?>" data-selected-product="<?= $productId ? (int)$productId : '' ?>">
+                                    <div class="line-item-header">
+                                        <h4 class="line-item-title">Item <?= $index + 1 ?></h4>
+                                        <button type="button" class="icon-btn remove-line-item" aria-label="Remove line item" <?= ($index === 0 || $formLocked) ? 'disabled' : '' ?>>
+                                            <i class="fas fa-trash"></i>
+                                        </button>
+                                    </div>
+                                    <div class="line-item-grid">
+                                        <div class="line-item-field product-field">
+                                            <label>Product <span class="required">*</span></label>
+                                            <div class="product-selector">
+                                                <div class="product-search-wrapper">
+                                                    <input type="text" class="product-search" placeholder="Search name or code" value="">
+                                                    <button type="button" class="product-clear" aria-label="Clear selected product" hidden>
+                                                        <i class="fas fa-times"></i>
+                                                    </button>
+                                                    <div class="product-suggestions"></div>
                                                 </div>
-                                            </td>
-                                            <td>
-                                                <input type="number" name="qty_expected[]" min="0" step="1" placeholder="0" value="<?= $qtyExpected !== null ? htmlspecialchars((string)$qtyExpected) : '' ?>">
-                                            </td>
-                                            <td>
-                                                <input type="number" name="qty_received[]" min="0" step="1" placeholder="0" value="<?= $qtyReceived !== null ? htmlspecialchars((string)$qtyReceived) : '' ?>" <?= $formLocked ? 'readonly' : 'required' ?>>
-                                            </td>
-                                            <td>
-                                                <input type="number" name="unit_cost[]" min="0" step="0.01" placeholder="0.00" value="<?= $unitCost !== null ? htmlspecialchars(number_format((float)$unitCost, 2, '.', '')) : '' ?>">
-                                            </td>
-                                            <td>
+                                                <select name="product_id[]" class="product-select" required>
+                                                    <option value="">Select product</option>
+                                                    <?php foreach ($products as $product): ?>
+                                                        <option value="<?= (int)$product['id'] ?>" <?= $productId == (int)$product['id'] ? 'selected' : '' ?>>
+                                                            <?= htmlspecialchars($product['name']) ?>
+                                                        </option>
+                                                    <?php endforeach; ?>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <div class="line-item-field">
+                                            <label>Qty Expected</label>
+                                            <input type="number" name="qty_expected[]" min="0" step="1" placeholder="0" value="<?= $qtyExpected !== null ? htmlspecialchars((string)$qtyExpected) : '' ?>">
+                                        </div>
+                                        <div class="line-item-field">
+                                            <label>Qty Received <span class="required">*</span></label>
+                                            <input type="number" name="qty_received[]" min="0" step="1" placeholder="0" value="<?= $qtyReceived !== null ? htmlspecialchars((string)$qtyReceived) : '' ?>" <?= $formLocked ? 'readonly' : 'required' ?>>
+                                        </div>
+                                        <div class="line-item-field">
+                                            <label>Unit Cost</label>
+                                            <input type="number" name="unit_cost[]" min="0" step="0.01" placeholder="0.00" value="<?= $unitCost !== null ? htmlspecialchars(number_format((float)$unitCost, 2, '.', '')) : '' ?>">
+                                        </div>
+                                        <div class="line-item-field">
+                                            <label>Expiry</label>
+                                            <div>
                                                 <input type="date" name="expiry_date[]" value="<?= $expiryDate ? htmlspecialchars($expiryDate) : '' ?>">
                                                 <?php if ($rowInvalidExpiry): ?>
                                                     <small class="input-error">Use YYYY-MM-DD (e.g., <?= date('Y-m-d') ?>).</small>
                                                 <?php endif; ?>
-                                            </td>
-                                            <td>
-                                                <input type="text" name="lot_number[]" placeholder="Lot or batch" value="<?= $lotNumber ? htmlspecialchars($lotNumber) : '' ?>">
-                                            </td>
-                                            <td class="actions">
-                                                <button type="button" class="icon-btn remove-line-item" aria-label="Remove line item" <?= ($index === 0 || $formLocked) ? 'disabled' : '' ?>>
-                                                    <i class="fas fa-trash"></i>
-                                                </button>
-                                            </td>
-                                        </tr>
-                                    <?php endforeach; ?>
-                                </tbody>
-                            </table>
+                                            </div>
+                                        </div>
+                                        <div class="line-item-field">
+                                            <label>Lot / Batch</label>
+                                            <input type="text" name="lot_number[]" placeholder="Lot or batch" value="<?= $lotNumber ? htmlspecialchars($lotNumber) : '' ?>">
+                                        </div>
+                                    </div>
+                                </div>
+                            <?php endforeach; ?>
                         </div>
                     </fieldset>
 

--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -304,10 +304,10 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
 
                     <?php if (!$formLocked): ?>
                         <div class="line-items-controls">
-                            <span class="line-items-hint">Add rows for each product received.</span>
                             <button type="button" class="btn-secondary" id="addLineItemBtn">
                                 <i class="fas fa-plus"></i> Add Line Item
                             </button>
+                            <span class="line-items-hint">Add rows for each product received.</span>
                         </div>
                     <?php endif; ?>
 
@@ -342,8 +342,10 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                                         <tr class="line-item-row<?= $rowHasDiscrepancy ? ' has-discrepancy' : '' ?>" data-selected-product="<?= $productId ? (int)$productId : '' ?>">
                                             <td>
                                                 <div class="product-selector">
-                                                    <input type="text" class="product-search" placeholder="Search name or code" value="">
-                                                    <div class="product-suggestions"></div>
+                                                    <div class="product-search-wrapper">
+                                                        <input type="text" class="product-search" placeholder="Search name or code" value="">
+                                                        <div class="product-suggestions"></div>
+                                                    </div>
                                                     <select name="product_id[]" class="product-select" required>
                                                         <option value="">Select product</option>
                                                         <?php foreach ($products as $product): ?>

--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -338,6 +338,9 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                                             <label>Product <span class="required">*</span></label>
                                             <div class="product-selector">
                                                 <div class="product-search-wrapper">
+                                                    <span class="product-search-icon" aria-hidden="true">
+                                                        <i class="fas fa-search"></i>
+                                                    </span>
                                                     <input type="text" class="product-search" placeholder="Search name or code" value="">
                                                     <button type="button" class="product-clear" aria-label="Clear selected product" hidden>
                                                         <i class="fas fa-times"></i>

--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -344,6 +344,9 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                                                 <div class="product-selector">
                                                     <div class="product-search-wrapper">
                                                         <input type="text" class="product-search" placeholder="Search name or code" value="">
+                                                        <button type="button" class="product-clear" aria-label="Clear selected product" hidden>
+                                                            <i class="fas fa-times"></i>
+                                                        </button>
                                                         <div class="product-suggestions"></div>
                                                     </div>
                                                     <select name="product_id[]" class="product-select" required>

--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -304,10 +304,10 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
 
                     <?php if (!$formLocked): ?>
                         <div class="line-items-controls">
+                            <span class="line-items-hint">Add rows for each product received.</span>
                             <button type="button" class="btn-secondary" id="addLineItemBtn">
                                 <i class="fas fa-plus"></i> Add Line Item
                             </button>
-                            <span class="line-items-hint">Add rows for each product received.</span>
                         </div>
                     <?php endif; ?>
 

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -109,7 +109,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    gap: 6px;
+    gap: 4px;
     margin: 0 0 12px;
 }
 
@@ -119,6 +119,7 @@
 
 .line-items-hint {
     display: block;
+    margin: 0;
     font-size: 12px;
     color: #64748b;
     text-align: right;
@@ -231,25 +232,19 @@
 
 .line-items-section .product-selector {
     position: relative;
-    display: grid;
-    gap: 10px;
     width: 100%;
-    max-width: none;
-    padding: 12px 14px;
-    border: 1px solid #e2e8f0;
-    border-radius: 12px;
-    background: #f8fafc;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.line-item-row.suggestions-open .product-selector {
-    border-color: #2563eb;
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
 }
 
 .line-items-section .product-search-wrapper {
     position: relative;
+    display: flex;
+    align-items: center;
     width: 100%;
+    min-height: 44px;
+    border: 1px solid #cbd5f5;
+    border-radius: 10px;
+    background: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .line-items-section .product-search-wrapper::before {
@@ -266,43 +261,74 @@
 }
 
 .line-items-section .product-search {
+    flex: 1;
     width: 100%;
-    padding: 10px 12px 10px 40px;
-    border: 1px solid #cbd5f5;
-    border-radius: 8px;
+    border: none;
+    background: transparent;
+    padding: 10px 42px 10px 40px;
     font-size: 14px;
-    background: #ffffff;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    color: #0f172a;
 }
 
 .line-items-section .product-search:focus {
     outline: none;
+}
+
+.line-items-section .product-search::placeholder {
+    color: #94a3b8;
+}
+
+.line-items-section .product-selector:focus-within .product-search-wrapper,
+.line-item-row.suggestions-open .product-search-wrapper {
     border-color: #2563eb;
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.line-items-section .product-clear {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: none;
+    color: #94a3b8;
+    cursor: pointer;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.line-items-section .product-clear:hover {
+    background: rgba(148, 163, 184, 0.16);
+    color: #475569;
+}
+
+.line-items-section .product-clear i {
+    font-size: 12px;
 }
 
 .line-items-section .product-selector select {
-    min-width: 100%;
-    max-width: 100%;
-    font-size: 13px;
-    padding: 10px 12px;
-    border-radius: 8px;
-    border: 1px solid #cbd5f5;
-    background: #ffffff;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.line-items-section .product-selector select:focus {
-    outline: none;
-    border-color: #2563eb;
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
 }
 
 .line-items-section .product-suggestions {
     position: absolute;
-    top: calc(100% + 2px);
-    left: 14px;
-    right: 14px;
+    top: calc(100% + 6px);
+    left: 0;
+    right: 0;
     z-index: 200;
     background: #ffffff;
     border: 1px solid #cbd5f5;
@@ -310,7 +336,7 @@
     border-radius: 12px;
     display: flex;
     flex-direction: column;
-    max-height: 320px;
+    max-height: 260px;
     overflow-y: auto;
     padding: 6px 0;
 }

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -128,7 +128,6 @@
 .line-items-section {
     position: relative;
     overflow: visible;
-    padding-bottom: 48px;
 }
 
 .form-section legend {
@@ -178,43 +177,108 @@
     color: #dc2626;
 }
 
-.table-wrapper {
-    overflow-x: auto;
-    overflow-y: visible;
-}
 
-.line-items-table {
-    width: 100%;
-    border-collapse: collapse;
-    min-width: 860px;
-}
-
-.line-items-table th,
-.line-items-table td {
-    border-bottom: 1px solid #e2e8f0;
-    padding: 12px;
-    text-align: left;
-    font-size: 14px;
-    vertical-align: top;
-}
-
-.line-items-table tbody tr:last-child td {
-    border-bottom: none;
-}
-
-.line-items-section .line-items-table td:first-child,
-.line-items-section .line-items-table th:first-child {
-    min-width: 480px;
-}
-
-.line-items-table thead th {
-    background: #f8fafc;
-    font-weight: 600;
-    color: #1f2937;
+.line-items-body {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    margin-top: 16px;
 }
 
 .line-item-row {
     position: relative;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    padding: 18px;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
+    overflow: visible;
+}
+
+.line-item-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.line-item-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.line-item-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px 20px;
+}
+
+.line-item-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.line-item-field > div {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.line-item-field label {
+    font-size: 12px;
+    font-weight: 600;
+    color: #475569;
+}
+
+.line-item-field input,
+.line-item-field select,
+.line-item-field .product-search-wrapper,
+.line-item-field .product-selector {
+    width: 100%;
+}
+
+.line-item-field input,
+.line-item-field select {
+    border-radius: 10px;
+    border: 1px solid #d1d5db;
+    padding: 10px 12px;
+    font-size: 14px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.line-item-field input:focus,
+.line-item-field select:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.product-field {
+    grid-column: 1 / -1;
+}
+
+.line-item-row .icon-btn {
+    color: #ef4444;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(239, 68, 68, 0.1);
+}
+
+.line-item-row .icon-btn:not(:disabled):hover {
+    background: rgba(239, 68, 68, 0.16);
+}
+
+.line-item-row .icon-btn:disabled {
+    background: rgba(148, 163, 184, 0.2);
+    color: #94a3b8;
 }
 
 .line-item-row.suggestions-open {
@@ -223,6 +287,7 @@
 
 .line-item-row.has-discrepancy {
     background: rgba(251, 191, 36, 0.12);
+    border-color: rgba(251, 191, 36, 0.6);
 }
 
 .line-item-row.has-discrepancy input,

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -231,11 +231,20 @@
 
 .line-items-section .product-selector {
     position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+    display: grid;
+    gap: 10px;
     width: 100%;
     max-width: none;
+    padding: 12px 14px;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    background: #f8fafc;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.line-item-row.suggestions-open .product-selector {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
 }
 
 .line-items-section .product-search-wrapper {
@@ -243,57 +252,104 @@
     width: 100%;
 }
 
+.line-items-section .product-search-wrapper::before {
+    content: '\f002';
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #94a3b8;
+    pointer-events: none;
+    font-size: 13px;
+}
+
 .line-items-section .product-search {
     width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #d1d5db;
+    padding: 10px 12px 10px 40px;
+    border: 1px solid #cbd5f5;
     border-radius: 8px;
     font-size: 14px;
+    background: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .line-items-section .product-search:focus {
     outline: none;
     border-color: #2563eb;
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
 }
 
 .line-items-section .product-selector select {
     min-width: 100%;
     max-width: 100%;
     font-size: 13px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid #cbd5f5;
+    background: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.line-items-section .product-selector select:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
 }
 
 .line-items-section .product-suggestions {
     position: absolute;
-    top: calc(100% + 4px);
-    left: 0;
-    right: 0;
+    top: calc(100% + 2px);
+    left: 14px;
+    right: 14px;
     z-index: 200;
     background: #ffffff;
     border: 1px solid #cbd5f5;
-    box-shadow: 0 24px 45px rgba(15, 23, 42, 0.18);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
     border-radius: 12px;
     display: flex;
     flex-direction: column;
     max-height: 320px;
     overflow-y: auto;
+    padding: 6px 0;
 }
 
 .line-items-section .product-suggestion-item {
-    padding: 12px 14px;
+    padding: 12px 16px;
     background: none;
     border: none;
     text-align: left;
     font-size: 13px;
     cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: #0f172a;
+    transition: background 0.15s ease;
+}
+
+.line-items-section .product-suggestion-item + .product-suggestion-item {
+    border-top: 1px solid #e2e8f0;
 }
 
 .line-items-section .product-suggestion-item:hover {
     background: #eff6ff;
 }
 
+.line-items-section .product-suggestion-name {
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.line-items-section .product-suggestion-meta {
+    font-size: 12px;
+    color: #64748b;
+    line-height: 1.2;
+}
+
 .line-items-section .product-suggestion-empty {
-    padding: 12px 14px;
+    padding: 12px 16px;
     font-size: 12px;
     color: #6b7280;
 }

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -111,6 +111,7 @@
     gap: 12px;
     margin: 0 0 16px;
     flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .line-items-controls .btn-secondary {
@@ -120,6 +121,10 @@
 .line-items-hint {
     font-size: 13px;
     color: #64748b;
+}
+
+.line-items-controls .btn-secondary {
+    margin-left: auto;
 }
 
 .line-items-section {
@@ -193,6 +198,10 @@
     text-align: left;
     font-size: 14px;
     vertical-align: top;
+}
+
+.line-items-table tbody tr:last-child td {
+    border-bottom: none;
 }
 
 .line-items-section .line-items-table td:first-child,

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -107,11 +107,10 @@
 
 .line-items-controls {
     display: flex;
-    align-items: center;
-    gap: 12px;
-    margin: 0 0 16px;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+    margin: 0 0 12px;
 }
 
 .line-items-controls .btn-secondary {
@@ -119,12 +118,10 @@
 }
 
 .line-items-hint {
-    font-size: 13px;
+    display: block;
+    font-size: 12px;
     color: #64748b;
-}
-
-.line-items-controls .btn-secondary {
-    margin-left: auto;
+    text-align: right;
 }
 
 .line-items-section {
@@ -241,6 +238,11 @@
     max-width: none;
 }
 
+.line-items-section .product-search-wrapper {
+    position: relative;
+    width: 100%;
+}
+
 .line-items-section .product-search {
     width: 100%;
     padding: 10px 12px;
@@ -263,10 +265,9 @@
 
 .line-items-section .product-suggestions {
     position: absolute;
-    top: 100%;
+    top: calc(100% + 4px);
     left: 0;
     right: 0;
-    margin-top: 8px;
     z-index: 200;
     background: #ffffff;
     border: 1px solid #cbd5f5;
@@ -492,6 +493,15 @@
         align-items: flex-start;
     }
 
+    .line-items-controls {
+        align-items: stretch;
+        gap: 8px;
+    }
+
+    .line-items-hint {
+        text-align: left;
+    }
+
     .line-items-section .product-selector {
         max-width: none;
     }
@@ -502,6 +512,7 @@
 
     .line-items-section .product-suggestions {
         position: static;
+        top: auto;
         margin-top: 4px;
         box-shadow: none;
         border-radius: 8px;

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -56,6 +56,7 @@
     font-size: 14px;
 }
 
+
 .panel-actions {
     display: flex;
     gap: 10px;
@@ -104,10 +105,27 @@
     margin-bottom: 24px;
 }
 
+.line-items-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0 0 16px;
+    flex-wrap: wrap;
+}
+
+.line-items-controls .btn-secondary {
+    padding-inline: 14px;
+}
+
+.line-items-hint {
+    font-size: 13px;
+    color: #64748b;
+}
+
 .line-items-section {
     position: relative;
     overflow: visible;
-    padding-bottom: 120px;
+    padding-bottom: 48px;
 }
 
 .form-section legend {
@@ -188,6 +206,14 @@
     color: #1f2937;
 }
 
+.line-item-row {
+    position: relative;
+}
+
+.line-item-row.suggestions-open {
+    z-index: 5;
+}
+
 .line-item-row.has-discrepancy {
     background: rgba(251, 191, 36, 0.12);
 }
@@ -202,12 +228,12 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    width: 70%;
-    max-width: 540px;
+    width: 100%;
+    max-width: none;
 }
 
 .line-items-section .product-search {
-    width: 80%;
+    width: 100%;
     padding: 10px 12px;
     border: 1px solid #d1d5db;
     border-radius: 8px;

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -310,19 +310,19 @@
     border-radius: 10px;
     background: #ffffff;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, border-radius 0.2s ease;
+    gap: 4px;
+    padding-left: 12px;
 }
 
-.line-items-section .product-search-wrapper::before {
-    content: '\f002';
-    font-family: 'Font Awesome 6 Free';
-    font-weight: 900;
-    position: absolute;
-    left: 14px;
-    top: 50%;
-    transform: translateY(-50%);
+.line-items-section .product-search-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    min-width: 24px;
     color: #94a3b8;
+    font-size: 14px;
     pointer-events: none;
-    font-size: 13px;
 }
 
 .line-items-section .product-search {
@@ -330,7 +330,7 @@
     width: 100%;
     border: none;
     background: transparent;
-    padding: 10px 42px 10px 40px;
+    padding: 10px 42px 10px 4px;
     font-size: 14px;
     color: #0f172a;
 }

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -244,7 +244,7 @@
     border: 1px solid #cbd5f5;
     border-radius: 10px;
     background: #ffffff;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, border-radius 0.2s ease;
 }
 
 .line-items-section .product-search-wrapper::before {
@@ -282,6 +282,12 @@
 .line-item-row.suggestions-open .product-search-wrapper {
     border-color: #2563eb;
     box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.line-item-row.suggestions-open .product-search-wrapper {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-color: transparent;
 }
 
 .line-items-section .product-clear {
@@ -326,19 +332,24 @@
 
 .line-items-section .product-suggestions {
     position: absolute;
-    top: calc(100% + 6px);
+    top: 100%;
     left: 0;
     right: 0;
     z-index: 200;
     background: #ffffff;
     border: 1px solid #cbd5f5;
-    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
-    border-radius: 12px;
+    border-top: none;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14);
+    border-radius: 0 0 12px 12px;
     display: flex;
     flex-direction: column;
     max-height: 260px;
     overflow-y: auto;
-    padding: 6px 0;
+    padding: 4px 0;
+}
+
+.line-item-row.suggestions-open .product-suggestions {
+    border-color: #9ac5ff;
 }
 
 .line-items-section .product-suggestion-item {
@@ -356,7 +367,7 @@
 }
 
 .line-items-section .product-suggestion-item + .product-suggestion-item {
-    border-top: 1px solid #e2e8f0;
+    border-top: 1px solid #f1f5f9;
 }
 
 .line-items-section .product-suggestion-item:hover {

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -352,7 +352,9 @@
 .line-item-row.suggestions-open .product-search-wrapper {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    border-bottom-color: transparent;
+    border-bottom-color: #9ac5ff;
+    border-left-color: #9ac5ff;
+    border-right-color: #9ac5ff;
 }
 
 .line-items-section .product-clear {
@@ -406,14 +408,21 @@
     border-top: none;
     box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14);
     border-radius: 0 0 12px 12px;
-    display: flex;
+    display: none;
     flex-direction: column;
     max-height: 260px;
     overflow-y: auto;
-    padding: 4px 0;
+    padding: 0;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
 }
 
 .line-item-row.suggestions-open .product-suggestions {
+    display: flex;
+    padding: 4px 0;
+    pointer-events: auto;
+    opacity: 1;
     border-color: #9ac5ff;
 }
 

--- a/dgz_motorshop_system/assets/js/inventory/stockEntry.js
+++ b/dgz_motorshop_system/assets/js/inventory/stockEntry.js
@@ -264,11 +264,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 emptyState.className = 'product-suggestion-empty';
                 emptyState.textContent = 'No matches found';
                 suggestions.appendChild(emptyState);
+                row.classList.add('suggestions-open');
+                suggestions.scrollTop = 0;
             }
             return;
         }
 
         row.classList.add('suggestions-open');
+        suggestions.scrollTop = 0;
 
         results.forEach((entry) => {
             const button = document.createElement('button');

--- a/dgz_motorshop_system/assets/js/inventory/stockEntry.js
+++ b/dgz_motorshop_system/assets/js/inventory/stockEntry.js
@@ -259,7 +259,30 @@ document.addEventListener('DOMContentLoaded', () => {
             button.type = 'button';
             button.className = 'product-suggestion-item';
             button.dataset.productId = entry.id;
-            button.textContent = entry.label;
+
+            const product = productMap.get(String(entry.id));
+            const name = product?.name || entry.label;
+            const metaParts = [];
+            if (product?.code) {
+                metaParts.push(`#${product.code}`);
+            }
+            if (product?.brand) {
+                metaParts.push(product.brand);
+            }
+            if (product?.category) {
+                metaParts.push(product.category);
+            }
+            const meta = metaParts.join(' • ');
+            const title = product ? buildProductLabel(product) : entry.label;
+            button.title = title;
+            if (meta) {
+                button.innerHTML = [
+                    `<span class="product-suggestion-name">${escapeHtml(name)}</span>`,
+                    `<span class="product-suggestion-meta">${escapeHtml(meta)}</span>`,
+                ].join('');
+            } else {
+                button.innerHTML = `<span class="product-suggestion-name">${escapeHtml(name)}</span>`;
+            }
             button.addEventListener('click', () => {
                 applyProductSelection(row, entry.id, { prefillSearch: false });
             });
@@ -322,6 +345,15 @@ document.addEventListener('DOMContentLoaded', () => {
             parts.push(`(${product.brand})`);
         }
         return parts.filter(Boolean).join(' ');
+    }
+
+    function escapeHtml(value) {
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
     }
 
     document.addEventListener('click', (event) => {

--- a/dgz_motorshop_system/assets/js/inventory/stockEntry.js
+++ b/dgz_motorshop_system/assets/js/inventory/stockEntry.js
@@ -218,12 +218,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const rows = Array.from(lineItemsBody.querySelectorAll('.line-item-row'));
         rows.forEach((row, index) => {
             const removeBtn = row.querySelector('.remove-line-item');
-            if (!removeBtn) {
-                return;
+            if (removeBtn) {
+                removeBtn.disabled = rows.length === 1;
+                if (index > 0) {
+                    removeBtn.disabled = false;
+                }
             }
-            removeBtn.disabled = rows.length === 1;
-            if (index > 0) {
-                removeBtn.disabled = false;
+        });
+        refreshLineItemLabels(rows);
+    }
+
+    function refreshLineItemLabels(rows = null) {
+        const lineRows = rows || Array.from(lineItemsBody.querySelectorAll('.line-item-row'));
+        lineRows.forEach((row, index) => {
+            const title = row.querySelector('.line-item-title');
+            if (title) {
+                title.textContent = `Item ${index + 1}`;
             }
         });
     }


### PR DESCRIPTION
## Summary
- reposition the stock-in line item controls and gate the discrepancy note so it only appears as required
- update line item styling and product search interactions to keep dropdowns visible and ready for new selections
- refresh the stock-in PDF export layout and align posted timestamps with the database clock

## Testing
- php -l dgz_motorshop_system/admin/stockEntry.php
- php -l dgz_motorshop_system/admin/stockReceiptView.php

------
https://chatgpt.com/codex/tasks/task_e_68e5d414dbf8832f8467be35e460b761