### PR TITLE
Add toggle controls to stock-in sections

### DIFF
--- a/dgz_motorshop_system/admin/inventory.php
+++ b/dgz_motorshop_system/admin/inventory.php
@@ -786,7 +786,7 @@ if(isset($_GET['export']) && $_GET['export'] == 'csv') {
         </div>
         <!-- Restock Request Form -->
 
-        <div id="restockRequestForm" class="restock-request hidden">
+        <div id="restockRequestForm" class="restock-request hidden" aria-hidden="true">
             <h3><i class="fas fa-clipboard-list"></i> Submit Restock Request</h3>
             <form method="post" class="restock-form"
                 data-initial-product="<?php echo htmlspecialchars($restockFormData['product']); ?>"

--- a/dgz_motorshop_system/admin/stockEntry.php
+++ b/dgz_motorshop_system/admin/stockEntry.php
@@ -258,8 +258,22 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                             <?php endif; ?>
                         </p>
                     </div>
+                    <div class="panel-actions">
+                        <button
+                            type="button"
+                            class="panel-toggle"
+                            data-toggle-target="stockInFormContainer"
+                            data-expanded-text="Hide Form"
+                            data-collapsed-text="Show Form"
+                            aria-expanded="true"
+                        >
+                            <i class="fas fa-chevron-up panel-toggle__icon" aria-hidden="true"></i>
+                            <span class="panel-toggle__label">Hide Form</span>
+                        </button>
+                    </div>
                 </div>
-                <form id="stockInForm" method="POST" enctype="multipart/form-data" <?= $formLocked ? 'aria-disabled="true"' : '' ?>>
+                <div id="stockInFormContainer" class="panel-content">
+                    <form id="stockInForm" method="POST" enctype="multipart/form-data" <?= $formLocked ? 'aria-disabled="true"' : '' ?>>
                     <?php if ($editingReceiptId): ?>
                         <input type="hidden" name="receipt_id" value="<?= (int)$editingReceiptId ?>">
                     <?php endif; ?>
@@ -421,7 +435,8 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                             <a class="btn-secondary" href="stockReceiptView.php?receipt=<?= (int)$activeReceipt['header']['id'] ?>">View Details</a>
                         <?php endif; ?>
                     </div>
-                </form>
+                    </form>
+                </div>
             </section>
 
             <!-- Stock-In report with filters, preview table, and export triggers -->
@@ -431,8 +446,22 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                         <h3 id="stockInReportTitle">Stock-In Report</h3>
                         <p class="panel-subtitle">Filter received stock entries and export the result set for external analysis.</p>
                     </div>
+                    <div class="panel-actions">
+                        <button
+                            type="button"
+                            class="panel-toggle"
+                            data-toggle-target="stockInReportContent"
+                            data-expanded-text="Hide Report"
+                            data-collapsed-text="Show Report"
+                            aria-expanded="true"
+                        >
+                            <i class="fas fa-chevron-up panel-toggle__icon" aria-hidden="true"></i>
+                            <span class="panel-toggle__label">Hide Report</span>
+                        </button>
+                    </div>
                 </div>
-                <form class="report-filters" method="GET" aria-label="Stock-In report filters">
+                <div id="stockInReportContent" class="panel-content">
+                    <form class="report-filters" method="GET" aria-label="Stock-In report filters">
                     <div class="form-grid">
                         <div class="form-group">
                             <label for="filter_date_from">Date From</label>
@@ -494,8 +523,8 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                         <button type="submit" class="btn-secondary" name="stock_in_export" value="csv">Export CSV</button>
                         <button type="submit" class="btn-secondary" name="stock_in_export" value="pdf">Export PDF</button>
                     </div>
-                </form>
-                <?php if (!empty($stockInReportRows)): ?>
+                    </form>
+                    <?php if (!empty($stockInReportRows)): ?>
                     <div class="table-wrapper">
                         <table class="data-table">
                             <thead>
@@ -528,9 +557,10 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                             </tbody>
                         </table>
                     </div>
-                <?php else: ?>
-                    <p class="empty-state">No stock-in activity matches the selected filters.</p>
-                <?php endif; ?>
+                    <?php else: ?>
+                        <p class="empty-state">No stock-in activity matches the selected filters.</p>
+                    <?php endif; ?>
+                </div>
             </section>
 
             <!-- Current inventory snapshot derived from latest stock-in posts -->
@@ -581,8 +611,22 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                         <h3 id="recentReceiptsTitle">Recent Stock-In Activity</h3>
                         <p class="panel-subtitle">Latest receipts with status and totals.</p>
                     </div>
+                    <div class="panel-actions">
+                        <button
+                            type="button"
+                            class="panel-toggle"
+                            data-toggle-target="recentReceiptsContent"
+                            data-expanded-text="Hide Activity"
+                            data-collapsed-text="Show Activity"
+                            aria-expanded="true"
+                        >
+                            <i class="fas fa-chevron-up panel-toggle__icon" aria-hidden="true"></i>
+                            <span class="panel-toggle__label">Hide Activity</span>
+                        </button>
+                    </div>
                 </div>
-                <?php if (!empty($recentReceipts)): ?>
+                <div id="recentReceiptsContent" class="panel-content">
+                    <?php if (!empty($recentReceipts)): ?>
                     <div class="table-wrapper">
                         <table class="data-table data-table--compact">
                             <thead>
@@ -619,9 +663,10 @@ $discrepancyGroupHiddenAttr = $hasPresetDiscrepancy ? '' : 'hidden';
                             </tbody>
                         </table>
                     </div>
-                <?php else: ?>
-                    <p class="empty-state">No stock-in documents recorded yet.</p>
-                <?php endif; ?>
+                    <?php else: ?>
+                        <p class="empty-state">No stock-in documents recorded yet.</p>
+                    <?php endif; ?>
+                </div>
             </section>
         </div>
     </main>

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -36,6 +36,10 @@
     padding: 24px;
 }
 
+.panel-content {
+    margin-top: 16px;
+}
+
 .panel-header {
     display: flex;
     align-items: flex-start;
@@ -60,6 +64,44 @@
 .panel-actions {
     display: flex;
     gap: 10px;
+}
+
+.panel-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    border: 1px solid #cbd5f5;
+    background: #f1f5f9;
+    color: #1f2937;
+    font-weight: 600;
+    font-size: 13px;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.panel-toggle:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(148, 163, 184, 0.2);
+    background: #e2e8f0;
+}
+
+.panel-toggle:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.35);
+}
+
+.panel-toggle__icon {
+    font-size: 14px;
+}
+
+.panel-toggle__label {
+    line-height: 1;
+}
+
+.hidden {
+    display: none !important;
 }
 
 .btn-secondary,

--- a/dgz_motorshop_system/assets/css/inventory/stockEntry.css
+++ b/dgz_motorshop_system/assets/css/inventory/stockEntry.css
@@ -66,30 +66,31 @@
     gap: 10px;
 }
 
+
 .panel-toggle {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    padding: 8px 14px;
-    border-radius: 8px;
-    border: 1px solid #cbd5f5;
-    background: #f1f5f9;
-    color: #1f2937;
+    padding: 8px 16px;
+    border-radius: 6px;
+    border: none;
+    background: #17a2b8;
+    color: #ffffff;
     font-weight: 600;
     font-size: 13px;
     cursor: pointer;
-    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
 .panel-toggle:hover {
     transform: translateY(-1px);
-    box-shadow: 0 8px 16px rgba(148, 163, 184, 0.2);
-    background: #e2e8f0;
+    box-shadow: 0 6px 14px rgba(23, 162, 184, 0.28);
+    background-color: #148fa1;
 }
 
 .panel-toggle:focus {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.35);
+    box-shadow: 0 0 0 3px rgba(23, 162, 184, 0.35);
 }
 
 .panel-toggle__icon {

--- a/dgz_motorshop_system/assets/js/inventory/stockEntry.js
+++ b/dgz_motorshop_system/assets/js/inventory/stockEntry.js
@@ -15,6 +15,49 @@ document.addEventListener('DOMContentLoaded', () => {
     const attachmentList = document.getElementById('attachmentList');
     const discrepancyRequiredIndicator = document.querySelector('[data-discrepancy-required]');
 
+    const panelToggleButtons = document.querySelectorAll('[data-toggle-target]');
+
+    panelToggleButtons.forEach((button) => {
+        const targetId = button.getAttribute('data-toggle-target');
+        if (!targetId) {
+            return;
+        }
+        const target = document.getElementById(targetId);
+        if (!target) {
+            return;
+        }
+
+        const collapsedText = button.getAttribute('data-collapsed-text') || 'Show';
+        const expandedText = button.getAttribute('data-expanded-text') || 'Hide';
+        const label = button.querySelector('.panel-toggle__label');
+        const icon = button.querySelector('.panel-toggle__icon');
+        const startCollapsed = button.getAttribute('data-start-collapsed') === 'true';
+
+        if (startCollapsed) {
+            target.classList.add('hidden');
+        }
+
+        const syncState = (isHidden) => {
+            button.setAttribute('aria-expanded', (!isHidden).toString());
+            if (label) {
+                label.textContent = isHidden ? collapsedText : expandedText;
+            }
+            if (icon) {
+                icon.className = `${isHidden ? 'fas fa-chevron-down' : 'fas fa-chevron-up'} panel-toggle__icon`;
+            }
+        };
+
+        syncState(target.classList.contains('hidden'));
+
+        button.addEventListener('click', () => {
+            const isHidden = target.classList.toggle('hidden');
+            syncState(isHidden);
+            if (!isHidden) {
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+
     if (!form || !lineItemsBody) {
         return;
     }


### PR DESCRIPTION
## Summary
- add collapsible toggle buttons to the stock-in form, stock-in report, and recent activity panels on stockEntry.php
- style the new toggle controls and hidden state to match the dashboard look and feel
- wire up JavaScript handlers so the panel buttons update labels/icons and reveal the requested section smoothly

## Testing
- php -l dgz_motorshop_system/admin/stockEntry.php

------
https://chatgpt.com/codex/tasks/task_e_68e5fdd7d9f8832faa1323d1db6c7032