### PR TITLE
Add customer order tracking page

### DIFF
--- a/dgz_motorshop_system/assets/css/public/track-order.css
+++ b/dgz_motorshop_system/assets/css/public/track-order.css
@@ -1,0 +1,379 @@
+/*
+ * Track order page styles
+ * -----------------------
+ * These rules mirror the existing public layout so that the header
+ * and navigation look identical to the rest of the storefront while
+ * adding bespoke styling for the tracking form and results area.
+ */
+
+/* Reset + base typography */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    background: #f8f9fa;
+    line-height: 1.6;
+    color: #2d3436;
+}
+
+/* Header styling kept identical to other public pages */
+.header {
+    background: #43d6ff;
+    padding: 10px 20px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 20px;
+}
+
+.logo {
+    width: 120px;
+    height: auto;
+}
+
+.logo img {
+    width: 100%;
+    height: auto;
+}
+
+.search-container {
+    flex: 1;
+    max-width: 400px;
+    position: relative;
+    margin: 0 auto;
+}
+
+.search-bar {
+    width: 100%;
+    margin-top: 19px;
+    padding: 10px 45px 10px 15px;
+    border: none;
+    border-radius: 20px;
+    font-size: 14px;
+    background: rgba(255, 255, 255, 0.9);
+}
+
+.search-btn {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: #666;
+    font-size: 16px;
+    cursor: pointer;
+    padding: 5px;
+}
+
+.cart-btn {
+    background: rgba(255, 255, 255, 0.2);
+    color: white;
+    padding: 0 22px;
+    border-radius: 24px;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    font-size: 15px;
+    flex-shrink: 0;
+    height: 46px;
+}
+
+.cart-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+    transform: translateY(-1px);
+}
+
+.cart-count {
+    background: #ff4757;
+    color: white;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: bold;
+}
+
+.nav {
+    background: white;
+    padding: 10px 0;
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.05);
+}
+
+.nav-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: center;
+    gap: 30px;
+}
+
+.nav-link {
+    color: #2d3436;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 14px;
+    padding: 8px 15px;
+    border-radius: 20px;
+    transition: all 0.3s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+    background: linear-gradient(135deg, #00bcd4 0%, #2196f3 100%);
+    color: white;
+}
+
+/* Tracker layout */
+.tracker-wrapper {
+    max-width: 1200px;
+    margin: 40px auto;
+    padding: 0 20px 60px;
+}
+
+.tracker-card {
+    background: white;
+    padding: 40px;
+    border-radius: 24px;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.08);
+}
+
+.tracker-card h1 {
+    font-size: 32px;
+    margin-bottom: 10px;
+}
+
+.tracker-card p {
+    color: #636e72;
+    margin-bottom: 30px;
+}
+
+/* Form styling */
+.tracker-form {
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+    margin-bottom: 30px;
+}
+
+.tracker-form label {
+    width: 100%;
+    font-weight: 600;
+    color: #2d3436;
+}
+
+.tracker-input {
+    flex: 1 1 260px;
+    padding: 14px 18px;
+    border-radius: 14px;
+    border: 1px solid #dfe6e9;
+    font-size: 16px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tracker-input:focus {
+    outline: none;
+    border-color: #00bcd4;
+    box-shadow: 0 0 0 3px rgba(0, 188, 212, 0.15);
+}
+
+.tracker-button {
+    background: linear-gradient(135deg, #00bcd4 0%, #2196f3 100%);
+    color: white;
+    border: none;
+    border-radius: 14px;
+    padding: 14px 28px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tracker-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 30px rgba(0, 188, 212, 0.3);
+}
+
+.tracker-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+/* Status display styling */
+.status-panel {
+    border-radius: 18px;
+    border: 1px solid #dfe6e9;
+    padding: 30px;
+    background: #f9fbfd;
+}
+
+.status-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.status-pill[data-status="pending"] {
+    background: rgba(253, 203, 110, 0.15);
+    color: #e17055;
+}
+
+.status-pill[data-status="approved"] {
+    background: rgba(85, 239, 196, 0.2);
+    color: #00b894;
+}
+
+.status-pill[data-status="completed"] {
+    background: rgba(9, 132, 227, 0.15);
+    color: #0984e3;
+}
+
+.status-pill[data-status="disapproved"],
+.status-pill[data-status="cancelled"],
+.status-pill[data-status="canceled"] {
+    background: rgba(214, 48, 49, 0.15);
+    color: #d63031;
+}
+
+.status-details {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.status-detail {
+    background: white;
+    border-radius: 14px;
+    padding: 16px 18px;
+    box-shadow: 0 12px 20px rgba(0, 0, 0, 0.04);
+}
+
+.status-detail span {
+    display: block;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: #95a5a6;
+    margin-bottom: 6px;
+}
+
+.status-detail strong {
+    font-size: 16px;
+    color: #2d3436;
+}
+
+/* Messaging */
+.feedback-message {
+    padding: 20px;
+    border-radius: 14px;
+    background: rgba(0, 0, 0, 0.03);
+    color: #2d3436;
+}
+
+.feedback-message.error {
+    background: rgba(214, 48, 49, 0.15);
+    color: #d63031;
+}
+
+.feedback-message.success {
+    background: rgba(85, 239, 196, 0.2);
+    color: #009688;
+}
+
+/* Footer styling mirrors other public pages */
+.footer {
+    background: #2d3436;
+    color: white;
+    padding: 40px 20px;
+}
+
+.footer-content {
+    max-width: 100%;
+    padding: 0 40px;
+    margin: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 40px;
+}
+
+.footer-column {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.footer-meta {
+    text-align: right;
+}
+
+.footer-meta .social-links {
+    margin-bottom: 10px;
+}
+
+.footer-meta a {
+    color: white;
+    margin-right: 10px;
+    font-size: 16px;
+}
+
+@media (max-width: 768px) {
+    .header-content {
+        flex-direction: column;
+    }
+
+    .search-container {
+        width: 100%;
+        max-width: none;
+    }
+
+    .cart-btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .tracker-card {
+        padding: 30px 24px;
+    }
+
+    .status-details {
+        grid-template-columns: 1fr;
+    }
+
+    .footer-content {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .footer-meta {
+        text-align: center;
+    }
+}

--- a/dgz_motorshop_system/assets/js/public/track-order.js
+++ b/dgz_motorshop_system/assets/js/public/track-order.js
@@ -1,0 +1,149 @@
+// Track order page interactions
+// ------------------------------
+// This script handles the lightweight order tracking flow:
+// 1. Capture the submitted order ID.
+// 2. Send it to the PHP endpoint for validation + lookup.
+// 3. Render the status or show an error message.
+
+(() => {
+    // Cache DOM references once the browser has parsed the markup.
+    const form = document.getElementById('orderTrackerForm');
+    const orderIdInput = document.getElementById('orderIdInput');
+    const feedbackContainer = document.getElementById('trackerFeedback');
+    const statusPanel = document.getElementById('trackerStatusPanel');
+    const statusPill = document.getElementById('trackerStatusPill');
+    const statusMessage = document.getElementById('trackerStatusMessage');
+    const statusDetails = document.getElementById('trackerStatusDetails');
+
+    if (!form || !orderIdInput) {
+        return; // Bail out if critical elements are missing.
+    }
+
+    // Helper to show feedback messages (success and error) in a single place.
+    const showFeedback = (message, type = 'info') => {
+        if (!feedbackContainer) {
+            return;
+        }
+
+        feedbackContainer.textContent = message;
+        feedbackContainer.classList.remove('error', 'success');
+
+        if (type === 'error') {
+            feedbackContainer.classList.add('error');
+        } else if (type === 'success') {
+            feedbackContainer.classList.add('success');
+        }
+
+        feedbackContainer.hidden = false;
+    };
+
+    // Helper to hide the feedback area entirely.
+    const hideFeedback = () => {
+        if (feedbackContainer) {
+            feedbackContainer.hidden = true;
+            feedbackContainer.textContent = '';
+            feedbackContainer.classList.remove('error', 'success');
+        }
+    };
+
+    // Helper to toggle the status panel visibility and populate its content.
+    const showStatus = (order) => {
+        if (!statusPanel || !statusPill || !statusMessage || !statusDetails) {
+            return;
+        }
+
+        // Update the pill styling + label based on the status from the API.
+        const normalizedStatus = (order.status || 'pending').toLowerCase();
+        statusPill.dataset.status = normalizedStatus;
+        statusPill.textContent = normalizedStatus.replace(/_/g, ' ');
+
+        // Show a simple friendly status line.
+        statusMessage.textContent = order.statusMessage || 'We found your order. Stay tuned for updates!';
+
+        // Populate the breakdown grid using template literals for clarity.
+        statusDetails.innerHTML = `
+            <div class="status-detail">
+                <span>Order ID</span>
+                <strong>#${order.id}</strong>
+            </div>
+            <div class="status-detail">
+                <span>Placed On</span>
+                <strong>${order.createdAt}</strong>
+            </div>
+            <div class="status-detail">
+                <span>Customer</span>
+                <strong>${order.customerName}</strong>
+            </div>
+            <div class="status-detail">
+                <span>Payment Method</span>
+                <strong>${order.paymentMethod}</strong>
+            </div>
+            <div class="status-detail">
+                <span>Order Total</span>
+                <strong>${order.total}</strong>
+            </div>
+        `;
+
+        statusPanel.hidden = false;
+    };
+
+    // Hide the status panel entirely (used when showing errors or prior to search).
+    const hideStatus = () => {
+        if (statusPanel) {
+            statusPanel.hidden = true;
+            statusDetails.innerHTML = '';
+        }
+    };
+
+    // Attach a submit handler so the page never performs a full reload.
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        hideFeedback();
+        hideStatus();
+
+        const rawOrderId = orderIdInput.value.trim();
+        if (rawOrderId === '') {
+            showFeedback('Please enter your order ID to continue.', 'error');
+            orderIdInput.focus();
+            return;
+        }
+
+        // Provide immediate feedback by disabling the button while the request is active.
+        const submitButton = form.querySelector('button[type="submit"]');
+        if (submitButton) {
+            submitButton.disabled = true;
+            submitButton.textContent = 'Checking...';
+        }
+
+        try {
+            const response = await fetch('order_status.php', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    orderId: rawOrderId,
+                }),
+            });
+
+            const data = await response.json();
+
+            if (!response.ok || !data.success) {
+                const errorMessage = data && data.message ? data.message : 'Unable to locate that order ID.';
+                showFeedback(errorMessage, 'error');
+                return;
+            }
+
+            showFeedback('Order found! See the latest update below.', 'success');
+            showStatus(data.order);
+        } catch (error) {
+            console.error('Order lookup failed:', error);
+            showFeedback('Something went wrong while checking your order. Please try again shortly.', 'error');
+        } finally {
+            if (submitButton) {
+                submitButton.disabled = false;
+                submitButton.textContent = 'Track Order';
+            }
+        }
+    });
+})();

--- a/dgz_motorshop_system/ordering/about.php
+++ b/dgz_motorshop_system/ordering/about.php
@@ -28,6 +28,7 @@
         <div class="nav-content">
             <a href="index.php" class="nav-link">HOME</a>
             <a href="about.php" class="nav-link active">ABOUT</a>
+            <a href="track-order.php" class="nav-link">TRACK ORDER</a>
 
         </div>
     </nav>

--- a/dgz_motorshop_system/ordering/index.php
+++ b/dgz_motorshop_system/ordering/index.php
@@ -58,8 +58,9 @@ natcasesort($categories);
     <!-- Navigation -->
     <nav class="nav">
         <div class="nav-content">
-            <a href="#home" class="nav-link active">HOME</a>
+            <a href="index.php" class="nav-link active">HOME</a>
             <a href="about.php" class="nav-link">ABOUT</a>
+            <a href="track-order.php" class="nav-link">TRACK ORDER</a>
 
         </div>
     </nav>

--- a/dgz_motorshop_system/ordering/order_status.php
+++ b/dgz_motorshop_system/ordering/order_status.php
@@ -1,0 +1,99 @@
+<?php
+// Allow the public order tracker to query order details securely.
+header('Content-Type: application/json');
+
+require_once __DIR__ . '/../config/config.php';
+
+// Only accept POST requests to keep the endpoint predictable.
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Unsupported request method.',
+    ]);
+    exit;
+}
+
+// Decode JSON payloads while still supporting standard form submissions as a fallback.
+$rawBody = file_get_contents('php://input');
+$decoded = json_decode($rawBody, true);
+
+$orderIdInput = null;
+if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+    $orderIdInput = $decoded['orderId'] ?? null;
+}
+
+if ($orderIdInput === null) {
+    $orderIdInput = $_POST['orderId'] ?? $_POST['order_id'] ?? null;
+}
+
+$orderId = filter_var($orderIdInput, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+if ($orderId === false) {
+    http_response_code(422);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Please provide a valid numeric order ID.',
+    ]);
+    exit;
+}
+
+try {
+    $pdo = db();
+
+    // Fetch a small, focused subset of the order information to share with customers.
+    $stmt = $pdo->prepare('SELECT id, customer_name, status, created_at, total, payment_method FROM orders WHERE id = ?');
+    $stmt->execute([$orderId]);
+    $order = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$order) {
+        http_response_code(404);
+        echo json_encode([
+            'success' => false,
+            'message' => 'We could not find an order with that ID. Please double check and try again.',
+        ]);
+        exit;
+    }
+
+    // Normalise values for consistent display in the UI.
+    $status = strtolower((string) ($order['status'] ?? 'pending'));
+    $statusMessages = [
+        'pending' => 'Your order is being reviewed by our team.',
+        'approved' => 'Great news! Your order has been approved and is moving to fulfillment.',
+        'completed' => 'Your order has been completed. Thank you for shopping with us!',
+        'disapproved' => 'Unfortunately this order was disapproved. Please contact our team for help.',
+        'cancelled' => 'This order has been cancelled.',
+        'canceled' => 'This order has been cancelled.',
+    ];
+
+    $formattedTotal = '₱' . number_format((float) ($order['total'] ?? 0), 2);
+    $createdAt = $order['created_at'] ?? '';
+    if ($createdAt !== '') {
+        try {
+            $createdAt = (new DateTime($createdAt))->format('M d, Y g:i A');
+        } catch (Exception $e) {
+            // Leave the original string if parsing fails.
+        }
+    }
+
+    echo json_encode([
+        'success' => true,
+        'order' => [
+            'id' => (int) $order['id'],
+            'customerName' => $order['customer_name'] !== '' ? $order['customer_name'] : 'Customer',
+            'status' => $status,
+            'statusMessage' => $statusMessages[$status] ?? 'We found your order. Stay tuned for updates!',
+            'createdAt' => $createdAt !== '' ? $createdAt : 'Processing',
+            'paymentMethod' => $order['payment_method'] !== '' ? $order['payment_method'] : 'Not specified',
+            'total' => $formattedTotal,
+        ],
+    ]);
+} catch (Throwable $exception) {
+    // Avoid leaking internal details while providing a helpful error message.
+    error_log('Order status lookup failed: ' . $exception->getMessage());
+
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Something went wrong while fetching your order status. Please try again later.',
+    ]);
+}

--- a/dgz_motorshop_system/ordering/track-order.php
+++ b/dgz_motorshop_system/ordering/track-order.php
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Track Your DGZ Motorshop Order</title>
+    <!-- Font Awesome for consistent iconography across the storefront -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <!-- Page specific stylesheet lives alongside the other public assets -->
+    <link rel="stylesheet" href="../assets/css/public/track-order.css">
+</head>
+<body>
+    <!-- Header: mirrors the home page layout so the experience feels seamless -->
+    <header class="header">
+        <div class="header-content">
+            <div class="logo">
+                <img src="../assets/logo.png" alt="DGZ Motorshop Logo">
+            </div>
+
+            <!-- Optional search bar retained for visual consistency with the homepage -->
+            <div class="search-container">
+                <input type="text" class="search-bar" placeholder="Search by Category, Part, Brand...">
+                <button class="search-btn" type="button" aria-label="Search">
+                    <i class="fas fa-search"></i>
+                </button>
+            </div>
+
+            <a href="#" class="cart-btn" id="cartButton">
+                <i class="fas fa-shopping-cart"></i>
+                <span>Cart</span>
+                <div class="cart-count" id="cartCount">0</div>
+            </a>
+        </div>
+    </header>
+
+    <!-- Navigation: adds the Track Order entry while keeping existing links -->
+    <nav class="nav">
+        <div class="nav-content">
+            <a href="index.php" class="nav-link">HOME</a>
+            <a href="about.php" class="nav-link">ABOUT</a>
+            <a href="track-order.php" class="nav-link active">TRACK ORDER</a>
+        </div>
+    </nav>
+
+    <!-- Main tracker module -->
+    <main class="tracker-wrapper">
+        <section class="tracker-card">
+            <h1>Track Your Order</h1>
+            <p>Enter the order ID from your confirmation message to see the latest status and important details.</p>
+
+            <!-- Order lookup form -->
+            <form id="orderTrackerForm" class="tracker-form">
+                <label for="orderIdInput">Order ID</label>
+                <input type="number" id="orderIdInput" name="order_id" class="tracker-input" placeholder="e.g. 1024" min="1" required>
+                <button type="submit" class="tracker-button">Track Order</button>
+            </form>
+
+            <!-- Feedback area for validation messages / API errors -->
+            <div id="trackerFeedback" class="feedback-message" hidden></div>
+
+            <!-- Status card displayed once a valid order is found -->
+            <div id="trackerStatusPanel" class="status-panel" hidden>
+                <div class="status-header">
+                    <div id="trackerStatusPill" class="status-pill" data-status="pending">pending</div>
+                    <p id="trackerStatusMessage">We found your order. Stay tuned for updates!</p>
+                </div>
+                <div id="trackerStatusDetails" class="status-details"></div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer reused from the other public pages -->
+    <footer class="footer">
+        <div class="footer-content">
+            <div class="footer-column contact-info">
+                <p><strong>Visit Us:</strong> Lot 2 Blk 3 Dolores Road, Brgy. Sto. Niño, Antipolo City</p>
+                <p><strong>Call:</strong> <a href="tel:+639123456789">+63 912 345 6789</a></p>
+                <p><strong>Email:</strong> <a href="mailto:orders@dgzmotorshop.com">orders@dgzmotorshop.com</a></p>
+            </div>
+            <div class="footer-column footer-meta">
+                <div class="social-links">
+                    <a href="https://www.facebook.com/dgzstonino"><i class="fab fa-facebook-f"></i></a>
+                </div>
+                <p>© 2022-2025 DGZ Motorshop - Sto. Niño Branch. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Shared cart functionality -->
+    <script src="../assets/js/public/cart.js"></script>
+    <!-- Page specific logic for handling status lookups -->
+    <script src="../assets/js/public/track-order.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Track Order page with the same public header layout so customers can check an order by ID
- implement an order_status.php endpoint plus supporting JavaScript to fetch and render live order status details
- create a matching stylesheet and update navigation links so the new page is accessible from existing views

## Testing
- php -l dgz_motorshop_system/ordering/track-order.php
- php -l dgz_motorshop_system/ordering/order_status.php

------
https://chatgpt.com/codex/tasks/task_e_68e693646e20832fa6048651d8031c7c