### PR TITLE
Add POS support for GCash and Maya payments

### DIFF
--- a/admin/pos.php
+++ b/admin/pos.php
@@ -71,6 +71,12 @@ function generateReceiptPDF(array $data): ?string {
 
         $html .= '</table>';
 
+        $paymentMethod = isset($data['payment_method']) ? (string) $data['payment_method'] : 'Cash';
+        if ($paymentMethod === '') {
+            $paymentMethod = 'Cash';
+        }
+        $paymentReference = isset($data['payment_reference']) ? (string) $data['payment_reference'] : '';
+
         // Totals section with vatable on the left and other totals on the right
         $html .= '<div style="display: flex; justify-content: space-between; width: 100%;">';
 
@@ -81,6 +87,12 @@ function generateReceiptPDF(array $data): ?string {
         $html .= '<p style="margin: 4px 0; font-weight: bold;">Total: PHP ' . number_format($data['sales_total'], 2) . '</p>';
         $html .= '<p style="margin: 4px 0;">Amount Paid: PHP ' . number_format($data['amount_paid'], 2) . '</p>';
         $html .= '<p style="margin: 4px 0;">Change: PHP ' . number_format($data['change'], 2) . '</p>';
+        $html .= '<p style="margin: 4px 0;"><strong>Payment Method:</strong> '
+            . htmlspecialchars($paymentMethod, ENT_QUOTES, 'UTF-8') . '</p>';
+        if ($paymentReference !== '') {
+            $html .= '<p style="margin: 4px 0;"><strong>Reference:</strong> '
+                . htmlspecialchars($paymentReference, ENT_QUOTES, 'UTF-8') . '</p>';
+        }
         $html .= '</div>';
 
         
@@ -1042,6 +1054,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_order_status']
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['pos_checkout'])) {
     $amountPaid = isset($_POST['amount_paid']) ? (float) $_POST['amount_paid'] : 0.0;
+    $rawPaymentMethod = isset($_POST['payment_method']) ? (string) $_POST['payment_method'] : 'cash';
+    $rawPaymentReference = isset($_POST['payment_reference']) ? (string) $_POST['payment_reference'] : '';
+    $paymentMethodMap = [
+        'cash' => 'Cash',
+        'gcash' => 'GCash',
+        'maya' => 'Maya',
+    ];
+    $selectedPaymentKey = strtolower(trim($rawPaymentMethod));
+    if (!array_key_exists($selectedPaymentKey, $paymentMethodMap)) {
+        $selectedPaymentKey = 'cash';
+    }
+    $paymentMethodLabel = $paymentMethodMap[$selectedPaymentKey];
+    $paymentReference = trim($rawPaymentReference);
+    if ($paymentReference !== '') {
+        $paymentReference = function_exists('mb_substr')
+            ? mb_substr($paymentReference, 0, 191)
+            : substr($paymentReference, 0, 191);
+    }
     $cartItems = [];
     $salesTotal = 0.0;
 
@@ -1243,6 +1273,28 @@ HTML;
         exit;
     }
 
+    if ($selectedPaymentKey !== 'cash' && $paymentReference === '') {
+        $_SESSION['pos_active_tab'] = 'walkin';
+        $message = json_encode('Please provide the payment reference for ' . $paymentMethodLabel . ' transactions.');
+        $destination = json_encode('pos.php');
+        echo <<<HTML
+<script>
+(function () {
+    var message = {$message};
+    var destination = {$destination};
+    var redirect = function () { window.location = destination; };
+    if (window.dgzAlert && typeof window.dgzAlert === 'function') {
+        window.dgzAlert(message).then(redirect);
+    } else {
+        alert(message);
+        redirect();
+    }
+})();
+</script>
+HTML;
+        exit;
+    }
+
     if ($amountPaid < $salesTotal) {
         $_SESSION['pos_active_tab'] = 'walkin';
         $message = json_encode('Insufficient payment amount!');
@@ -1328,6 +1380,7 @@ HTML;
     $orderVatableColumn = ordersFindColumn($pdo, ['vatable']);
     $orderVatColumn = ordersFindColumn($pdo, ['vat', 'tax']);
     $orderAmountPaidColumn = ordersFindColumn($pdo, ['amount_paid', 'amountpaid', 'amount_paid_total', 'paid_amount', 'payment_amount']);
+    $orderReferenceColumn = ordersFindColumn($pdo, ['reference_no', 'reference_number', 'reference', 'ref_no']);
     $orderChangeColumn = ordersFindColumn($pdo, ['change_amount', 'change']);
     $orderCreatedAtColumn = ordersFindColumn($pdo, ['created_at', 'order_date', 'ordered_at', 'date_created']);
 
@@ -1369,7 +1422,7 @@ HTML;
         }
 
         $appendColumn($orderTotalColumn, $salesTotal);
-        $appendColumn($orderPaymentMethodColumn, 'Cash');
+        $appendColumn($orderPaymentMethodColumn, $paymentMethodLabel);
         $appendColumn($orderTypeColumn, 'walkin');
         $appendColumn($orderStatusColumn, 'completed');
 
@@ -1379,6 +1432,9 @@ HTML;
         $appendColumn($orderVatableColumn, $vatable);
         $appendColumn($orderVatColumn, $vat);
         $appendColumn($orderAmountPaidColumn, $amountPaid);
+        if ($orderReferenceColumn !== null && $paymentReference !== '') {
+            $appendColumn($orderReferenceColumn, $paymentReference);
+        }
         $appendColumn($orderChangeColumn, $change);
 
         if ($orderInvoiceNumberColumn !== null && $supportsInvoiceNumbers) {
@@ -1447,6 +1503,8 @@ HTML;
             'vat' => $vat,
             'amount_paid' => $amountPaid,
             'change' => $change,
+            'payment_method' => $paymentMethodLabel,
+            'payment_reference' => $paymentReference,
             'cashier' => currentSessionUserDisplayName() ?? 'Cashier',
             'items' => array_map(static function (array $item): array {
                 return [
@@ -1485,6 +1543,10 @@ HTML;
             $html .= '<p><strong>Total Amount:</strong> ₱' . number_format($salesTotal, 2) . '</p>';
             $html .= '<p><strong>Amount Paid:</strong> ₱' . number_format($amountPaid, 2) . '</p>';
             $html .= '<p><strong>Change:</strong> ₱' . number_format($change, 2) . '</p>';
+            $html .= '<p><strong>Payment Method:</strong> ' . htmlspecialchars($paymentMethodLabel, ENT_QUOTES, 'UTF-8') . '</p>';
+            if ($paymentReference !== '') {
+                $html .= '<p><strong>Reference:</strong> ' . htmlspecialchars($paymentReference, ENT_QUOTES, 'UTF-8') . '</p>';
+            }
 
             $dompdf->loadHtml($html);
             $dompdf->setPaper('A4', 'portrait');
@@ -1720,6 +1782,12 @@ if (isset($_GET['ok'], $_GET['order_id']) && $_GET['ok'] === '1') {
         $orderSelectColumns[] = $orderCreatedAtColumn !== null
             ? $quoteIdentifier($orderCreatedAtColumn) . ' AS created_at'
             : 'CURRENT_TIMESTAMP AS created_at';
+        $orderSelectColumns[] = $orderPaymentMethodColumn !== null
+            ? $quoteIdentifier($orderPaymentMethodColumn) . ' AS payment_method'
+            : "'Cash' AS payment_method";
+        $orderSelectColumns[] = $orderReferenceColumn !== null
+            ? $quoteIdentifier($orderReferenceColumn) . ' AS payment_reference'
+            : "'' AS payment_reference";
         if ($orderInvoiceNumberColumn !== null) {
             $orderSelectColumns[] = $quoteIdentifier($orderInvoiceNumberColumn) . ' AS invoice_number';
         } else {
@@ -1772,6 +1840,8 @@ if (isset($_GET['ok'], $_GET['order_id']) && $_GET['ok'] === '1') {
                 'vat' => (float) ($orderRow['vat'] ?? 0),
                 'amount_paid' => (float) ($orderRow['amount_paid'] ?? 0),
                 'change' => (float) ($orderRow['change_amount'] ?? 0),
+                'payment_method' => (string) ($orderRow['payment_method'] ?? 'Cash'),
+                'payment_reference' => (string) ($orderRow['payment_reference'] ?? ''),
                 'cashier' => (string) (currentSessionUserDisplayName() ?? 'Cashier'),
                 'items' => $items,
             ];
@@ -1888,6 +1958,18 @@ if ($receiptDataJson === false) {
                     <div class="totals-item">
                         <label for="amountReceived">Amount Received</label>
                         <input type="number" id="amountReceived" name="amount_paid" min="0" step="0.01" placeholder="0.00">
+                    </div>
+                    <div class="totals-item">
+                        <label for="paymentMethod">Payment Method</label>
+                        <select id="paymentMethod" name="payment_method">
+                            <option value="cash" selected>Cash</option>
+                            <option value="gcash">GCash</option>
+                            <option value="maya">Maya</option>
+                        </select>
+                    </div>
+                    <div class="totals-item" data-payment-reference-wrapper hidden>
+                        <label for="paymentReference">Reference No.</label>
+                        <input type="text" id="paymentReference" name="payment_reference" maxlength="191" placeholder="Enter reference number" autocomplete="off">
                     </div>
                     <div class="totals-item">
                         <label>Change</label>
@@ -2454,6 +2536,8 @@ if ($receiptDataJson === false) {
                     <div><span>VAT (12%):</span> <span id="receiptVat">₱0.00</span></div>
                     <div><span>Amount Paid:</span> <span id="receiptAmountPaid">₱0.00</span></div>
                     <div><span>Change:</span> <span id="receiptChange">₱0.00</span></div>
+                    <div><span>Payment Method:</span> <span id="receiptPaymentMethod">Cash</span></div>
+                    <div id="receiptReferenceRow" hidden><span>Reference:</span> <span id="receiptPaymentReference">N/A</span></div>
                 </div>
                 <div class="receipt-footer">
                     <p>Thank you for shopping!</p>

--- a/admin/pos.php
+++ b/admin/pos.php
@@ -1569,6 +1569,14 @@ HTML;
             $params['invoice_number'] = $invoiceNumber;
         }
 
+        if ($paymentMethodLabel !== '') {
+            $params['payment_method'] = $paymentMethodLabel;
+        }
+
+        if ($paymentReference !== '') {
+            $params['payment_reference'] = $paymentReference;
+        }
+
         header('Location: pos.php?' . http_build_query($params));
         exit;
     } catch (Throwable $exception) {

--- a/dgz_motorshop_system/assets/css/pos/pos.css
+++ b/dgz_motorshop_system/assets/css/pos/pos.css
@@ -865,8 +865,10 @@ body {
 }
 
 #paymentReference {
+    width: min(100%, 360px);
     max-width: 100%;
     letter-spacing: 0.02em;
+    justify-self: start;
 }
 
 .totals-panel [data-payment-reference-wrapper] {

--- a/dgz_motorshop_system/assets/css/pos/pos.css
+++ b/dgz_motorshop_system/assets/css/pos/pos.css
@@ -202,7 +202,7 @@ body {
 
 /* POS Table Container - fixed height, scrollable, for sticky header */
 .pos-table-container {
-    height: 610px;
+    height: 520px;
     overflow-y: auto;
     overflow-x: hidden;
     border: 1px solid #e2e8f0;
@@ -794,11 +794,11 @@ body {
 }
 
 /* ADDED: Empty state styling for when no items are in POS table */
-.pos-empty-state {  
+.pos-empty-state {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 610px;
+    min-height: 100%;
     color: #9ca3af;
     font-size: 16px;
     text-align: center;
@@ -842,13 +842,35 @@ body {
     color: #1f2937;
 }
 
-#amountReceived{
+#amountReceived,
+#paymentMethod,
+#paymentReference{
     width:100%;
     height: 40px;
     padding: 8px 10px;
     border: 1px solid #e2e8f0;
     border-radius: 6px;
     font-size: 14px;
+}
+
+#paymentMethod {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8" fill="none"%3E%3Cpath d="M1 1.5L6 6.5L11 1.5" stroke="%236b7280" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E');
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 12px 8px;
+    padding-right: 32px;
+}
+
+#paymentReference {
+    max-width: 100%;
+    letter-spacing: 0.02em;
+}
+
+.totals-panel [data-payment-reference-wrapper] {
+    grid-column: span 2;
 }
 
 /* POS Buttons */

--- a/dgz_motorshop_system/assets/js/pos/posMain.js
+++ b/dgz_motorshop_system/assets/js/pos/posMain.js
@@ -2014,6 +2014,16 @@ document.addEventListener('DOMContentLoaded', () => {
                     createdAt = new Date();
                 }
 
+                const paramPaymentMethod = (params.get('payment_method') || '').trim();
+                if (paramPaymentMethod !== '') {
+                    paymentMethodLabel = paramPaymentMethod;
+                }
+
+                const paramPaymentReference = (params.get('payment_reference') || '').trim();
+                if (paramPaymentReference !== '') {
+                    paymentReferenceValue = paramPaymentReference;
+                }
+
                 receiptItemsBody.innerHTML = '';
                 items.forEach((item) => {
                     const row = document.createElement('tr');

--- a/dgz_motorshop_system/assets/js/pos/posMain.js
+++ b/dgz_motorshop_system/assets/js/pos/posMain.js
@@ -73,6 +73,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const posEmptyState = document.getElementById('posEmptyState');
             const amountReceivedInput = document.getElementById('amountReceived');
             const settlePaymentButton = document.getElementById('settlePaymentButton');
+            const paymentMethodSelect = document.getElementById('paymentMethod');
+            const paymentReferenceWrapper = document.querySelector('[data-payment-reference-wrapper]');
+            const paymentReferenceInput = document.getElementById('paymentReference');
             const profileButton = document.getElementById('profileTrigger');
             const profileModal = document.getElementById('profileModal');
             const profileModalClose = document.getElementById('profileModalClose');
@@ -114,6 +117,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const closeReceiptModalButton = document.getElementById('closeReceiptModal');
             const printReceiptButton = document.getElementById('printReceiptButton');
             const receiptItemsBody = document.getElementById('receiptItemsBody');
+            const receiptPaymentMethodEl = document.getElementById('receiptPaymentMethod');
+            const receiptReferenceRow = document.getElementById('receiptReferenceRow');
+            const receiptPaymentReferenceEl = document.getElementById('receiptPaymentReference');
 
             const proofModal = document.getElementById('proofModal');
             const proofImage = document.getElementById('proofImage');
@@ -1052,6 +1058,51 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             // End POS cart total calculator
 
+            function getSelectedPaymentMethodKey() {
+                if (!paymentMethodSelect) {
+                    return 'cash';
+                }
+                return String(paymentMethodSelect.value || 'cash').toLowerCase();
+            }
+
+            function requiresReferenceForMethod(methodKey) {
+                return methodKey === 'gcash' || methodKey === 'maya';
+            }
+
+            function getPaymentMethodLabel(methodKey) {
+                switch (methodKey) {
+                    case 'gcash':
+                        return 'GCash';
+                    case 'maya':
+                        return 'Maya';
+                    default:
+                        return 'Cash';
+                }
+            }
+
+            function updatePaymentMethodUI() {
+                const methodKey = getSelectedPaymentMethodKey();
+                const needsReference = requiresReferenceForMethod(methodKey);
+
+                if (paymentReferenceWrapper) {
+                    paymentReferenceWrapper.hidden = !needsReference;
+                    paymentReferenceWrapper.setAttribute('aria-hidden', needsReference ? 'false' : 'true');
+                }
+
+                if (!needsReference && paymentReferenceInput) {
+                    paymentReferenceInput.value = '';
+                }
+
+                if (paymentReferenceInput) {
+                    const label = getPaymentMethodLabel(methodKey);
+                    paymentReferenceInput.placeholder = needsReference
+                        ? `${label} reference number`
+                        : 'Enter reference number';
+                }
+
+                updateSettleButtonState();
+            }
+
             // Begin POS settle button enabler
             function updateSettleButtonState() {
                 if (!settlePaymentButton) {
@@ -1062,9 +1113,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 const amountReceivedRaw = amountReceivedInput ? amountReceivedInput.value || '0' : '0';
                 const amountReceived = parseFloat(amountReceivedRaw);
                 const salesTotal = getSalesTotal();
-                
+                const methodKey = getSelectedPaymentMethodKey();
+                const needsReference = requiresReferenceForMethod(methodKey);
+                const referenceValue = paymentReferenceInput ? paymentReferenceInput.value : '';
+                const hasReference = !needsReference || String(referenceValue).trim() !== '';
+
                 // Only enable if there are items and payment is sufficient
-                const shouldEnable = hasRows && amountReceived >= salesTotal && salesTotal > 0;
+                const shouldEnable = hasRows
+                    && amountReceived >= salesTotal
+                    && salesTotal > 0
+                    && hasReference;
 
                 settlePaymentButton.disabled = !shouldEnable;
             }
@@ -1174,6 +1232,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (amountReceivedInput) {
                     amountReceivedInput.value = '';
                 }
+                if (paymentReferenceInput) {
+                    paymentReferenceInput.value = '';
+                }
+                if (paymentMethodSelect) {
+                    paymentMethodSelect.value = 'cash';
+                }
+                updatePaymentMethodUI();
                 recalcTotals();
                 try {
                     localStorage.removeItem(posStateKey);
@@ -1865,6 +1930,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 let createdAt = new Date();
                 let orderId = params.get('order_id') || '';
                 let invoiceNumber = params.get('invoice_number') || '';
+                let paymentMethodLabel = 'Cash';
+                let paymentReferenceValue = '';
 
                 if (hasServerReceipt) {
                     items = checkoutReceipt.items.map((item) => {
@@ -1885,6 +1952,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     amountPaid = Number(checkoutReceipt.amount_paid) || parseFloat(params.get('amount_paid') || '0');
                     change = Number(checkoutReceipt.change) || parseFloat(params.get('change') || '0');
                     cashierName = checkoutReceipt.cashier || cashierName;
+                    paymentMethodLabel = checkoutReceipt.payment_method
+                        ? String(checkoutReceipt.payment_method)
+                        : paymentMethodLabel;
+                    paymentReferenceValue = checkoutReceipt.payment_reference
+                        ? String(checkoutReceipt.payment_reference)
+                        : paymentReferenceValue;
 
                     if (checkoutReceipt.order_id) {
                         orderId = checkoutReceipt.order_id;
@@ -1965,6 +2038,22 @@ document.addEventListener('DOMContentLoaded', () => {
                 document.getElementById('receiptVat').textContent = formatPeso(vat);
                 document.getElementById('receiptAmountPaid').textContent = formatPeso(amountPaid);
                 document.getElementById('receiptChange').textContent = formatPeso(change);
+                if (receiptPaymentMethodEl) {
+                    const label = String(paymentMethodLabel || 'Cash').trim();
+                    receiptPaymentMethodEl.textContent = label !== '' ? label : 'Cash';
+                }
+                if (receiptReferenceRow && receiptPaymentReferenceEl) {
+                    const safeReference = String(paymentReferenceValue || '').trim();
+                    if (safeReference !== '') {
+                        receiptPaymentReferenceEl.textContent = safeReference;
+                        receiptReferenceRow.hidden = false;
+                        receiptReferenceRow.setAttribute('aria-hidden', 'false');
+                    } else {
+                        receiptPaymentReferenceEl.textContent = 'N/A';
+                        receiptReferenceRow.hidden = true;
+                        receiptReferenceRow.setAttribute('aria-hidden', 'true');
+                    }
+                }
 
                 receiptModal.style.display = 'flex';
 
@@ -2432,6 +2521,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             }
 
+            if (paymentMethodSelect) {
+                paymentMethodSelect.addEventListener('change', () => {
+                    updatePaymentMethodUI();
+                });
+            }
+
+            if (paymentReferenceInput) {
+                paymentReferenceInput.addEventListener('input', () => {
+                    updateSettleButtonState();
+                });
+            }
+
+            updatePaymentMethodUI();
+
             if (clearPosTableButton) {
                 clearPosTableButton.addEventListener('click', () => {
                     clearTable();
@@ -2459,6 +2562,29 @@ document.addEventListener('DOMContentLoaded', () => {
                             amountReceivedInput.focus();
                         }
                         return;
+                    }
+
+                    const methodKey = getSelectedPaymentMethodKey();
+                    if (requiresReferenceForMethod(methodKey)) {
+                        const referenceValue = paymentReferenceInput ? paymentReferenceInput.value.trim() : '';
+                        if (referenceValue === '') {
+                            event.preventDefault();
+                            let paymentLabel = getPaymentMethodLabel(methodKey);
+                            if (paymentMethodSelect
+                                && typeof paymentMethodSelect.selectedIndex === 'number'
+                                && paymentMethodSelect.selectedIndex >= 0
+                                && paymentMethodSelect.options[paymentMethodSelect.selectedIndex]) {
+                                paymentLabel = paymentMethodSelect
+                                    .options[paymentMethodSelect.selectedIndex]
+                                    .text
+                                    .trim();
+                            }
+                            showPosAlert(`Please enter the ${paymentLabel} reference number before completing the payment.`);
+                            if (paymentReferenceInput) {
+                                paymentReferenceInput.focus();
+                            }
+                            return;
+                        }
                     }
 
                 if (amountReceived < salesTotal) {


### PR DESCRIPTION
## Summary
- add a payment method selector and reference field to POS checkout so staff can capture cash, GCash, or Maya payments
- persist the selected payment method and reference in orders and generated receipts, including the PDF output and on-screen receipt modal
- update the POS frontend logic to require references for digital payments, toggle the new field, and show the details on the receipt display

## Testing
- php -l admin/pos.php

------
https://chatgpt.com/codex/tasks/task_e_68fead882dac832f8ee98fa527c9c672