### PR TITLE
Add best seller sorting option to storefront

### DIFF
--- a/dgz_motorshop_system/assets/css/public/index.css
+++ b/dgz_motorshop_system/assets/css/public/index.css
@@ -466,6 +466,9 @@ body.nav-open {
     font-weight: 500;
     color: #546e7a;
     text-transform: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .sidebar-backdrop {

--- a/dgz_motorshop_system/assets/js/public/mobileFilters.js
+++ b/dgz_motorshop_system/assets/js/public/mobileFilters.js
@@ -180,6 +180,18 @@
                 sorted = cards.sort(function (a, b) {
                     return parseFloat(b.dataset.productPrice || '0') - parseFloat(a.dataset.productPrice || '0');
                 });
+            } else if (mode === 'best-seller') {
+                sorted = cards.sort(function (a, b) {
+                    var soldB = parseInt(b.dataset.productSold || '0', 10);
+                    var soldA = parseInt(a.dataset.productSold || '0', 10);
+                    if (isNaN(soldB)) {
+                        soldB = 0;
+                    }
+                    if (isNaN(soldA)) {
+                        soldA = 0;
+                    }
+                    return soldB - soldA;
+                });
             } else if (mode === 'newest') {
                 sorted = cards.sort(function (a, b) {
                     var createdB = parseInt(b.dataset.productCreated || '0', 10);


### PR DESCRIPTION
## Summary
- compute best-seller totals for products based on qualifying order statuses
- expose best-seller metrics to the storefront and add desktop/mobile sort options
- enable client-side sorting of catalog cards by total units sold

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ff81f1f92c832f882d2e701b87c036